### PR TITLE
fix: implement merchant dashboard page header with actions

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,75 @@
+import { Link } from 'react-router-dom'
+
 export default function Dashboard() {
   return (
     <div style={{ padding: '1.5rem 2rem', background: '#0a0a0a', minHeight: '100vh' }}>
-      <h1 style={{ margin: '0 0 1rem', fontSize: '1.5rem', color: '#e2e8f0' }}>Dashboard</h1>
-      <p style={{ color: '#64748b' }}>
-        Overview of your subscription metrics and revenue. Connect the backend API to load real data.
-      </p>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '1rem', marginTop: '1.5rem' }}>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: '1rem',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <div>
+          <h1 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 700, color: '#e2e8f0' }}>
+            Dashboard
+          </h1>
+          <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem', color: '#64748b' }}>
+            Overview of your subscription business &middot; Last 30 days
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <Link
+            to="/plans"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.5rem 1rem',
+              borderRadius: '0.5rem',
+              border: '1px solid rgba(255,255,255,0.25)',
+              background: 'transparent',
+              color: '#e2e8f0',
+              fontSize: '0.875rem',
+              textDecoration: 'none',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            View plans
+          </Link>
+          <Link
+            to="/plans?create=true"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.5rem 1rem',
+              borderRadius: '0.5rem',
+              border: 'none',
+              background: 'linear-gradient(135deg, #67d5f0, #5ce0b8)',
+              color: '#fff',
+              fontSize: '0.875rem',
+              fontWeight: 600,
+              textDecoration: 'none',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            Create plan
+          </Link>
+        </div>
+      </header>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '1rem' }}>
         <Card title="Active Subscriptions" value="—" />
         <Card title="MRR" value="—" />
         <Card title="Pending Charges" value="—" />


### PR DESCRIPTION

Closes #47
## Summary

Implements the dashboard page header per the design in issue #47.

Add title, subtitle, View plans (outline + eye icon) and Create plan (gradient + plus icon) buttons to the dashboard header. Responsive flex layout with dark theme styling.

## Root Cause

The dashboard page had a plain title and description paragraph with no
action buttons or proper header layout matching the Figma design.

## Fix

Replaced the flat header markup in `Dashboard.tsx` with a flex-based
`<header>` element containing:
- Left: "Dashboard" title (bold, white) and subtitle with date range (muted gray)
- Right: "View plans" link (outline style, eye icon, routes to /plans)
  and "Create plan" link (blue-to-green gradient, plus icon, routes to /plans?create=true)

Uses `Link` from react-router-dom for navigation. Responsive via
flexWrap. Inline styles consistent with existing codebase patterns.

## Testing

- Verified no new TypeScript errors introduced (all reported errors are
  pre-existing missing type declarations across every file)
- Verified file compiles without IDE errors
- No test framework present in repo; no tests to update

## CI

No CI workflows configured. Build script validates cleanly for the
changed file.