### PR TITLE
Prepaid balance card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import Dashboard from './pages/Dashboard'
 import Subscriptions from './pages/Subscriptions'
 import Plans from './pages/Plans'
 import Landing from './pages/Landing'
-import PrepaidBalanceCard from './components/PrepaidBalance'
 
 function App() {
   return (

--- a/src/components/PrepaidBalance.tsx
+++ b/src/components/PrepaidBalance.tsx
@@ -9,7 +9,7 @@ export const DollarIcon = ({ size = 20, color = "#00D3F2" }) => {
 }
 
 
-export default function PrepaidBalanceCard({ balance = 30, maxBalance = 30, paymentAmount = 10 }) {
+export default function PrepaidBalanceCard({ balance = 30, maxBalance = 30, paymentAmount = 10, onTopUp }: {balance:number, maxBalance:number, paymentAmount:number, onTopUp:()=>void}) {
     const payments = Math.floor(balance / paymentAmount);
     const fillPct = Math.min((balance / maxBalance) * 100, 100);
 
@@ -50,7 +50,7 @@ export default function PrepaidBalanceCard({ balance = 30, maxBalance = 30, paym
                     </div>
                 </div>
 
-                <button className="prepaid-card__button" aria-label="Top up balance">
+                <button className="prepaid-card__button" aria-label="Top up balance" onClick={onTopUp}>
                     <DollarIcon size={16} color="black" />
                     <span className="prepaid-card__button-text">Top up balance</span>
                 </button>

--- a/src/components/prepaidCard.css
+++ b/src/components/prepaidCard.css
@@ -10,6 +10,7 @@
     background: linear-gradient(135deg, rgba(0,184,219,0.1) 0%, rgba(0,187,167,0.1) 100%);
     border: 1px solid rgba(0,184,219,0.2);
     border-radius: 1rem;
+    box-shadow: 0 0 24px rgba(0, 184, 219, 0.15), 0 0 48px rgba(0, 187, 167, 0.001);
 }
 
 .prepaid-card__header {


### PR DESCRIPTION
Closes #61

---

feat: implement PrepaidBalanceCard component
- Add PrepaidBalanceCard with teal $ icon, balance display, coverage text, progress bar, and top up button
- Add DollarIcon component with dynamic size and color props
- put all styles in prepaidCard.css with BEM naming
- Convert all px values to rem for responsiveness
- Fix DollarIcon second path stroke color hardcoded to #00D3F2 — now uses color prop
- Add box-shadow teal edge glow to card container
- Wire onTopUp prop to button onClick
- Add ARIA attributes to progress bar for accessibility