### PR TITLE
feat: implement FAQ accordion section

### DIFF
--- a/src/components/Landing/FAQ.module.css
+++ b/src/components/Landing/FAQ.module.css
@@ -1,0 +1,109 @@
+.faqSection {
+  padding: 6rem 0;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.faqHeading {
+  color: #ffffff;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2.5rem;
+}
+
+.accordionList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.accordionItem {
+  background: #0f1922;
+  border: 1px solid #1e2d3d;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.accordionItem:hover {
+  border-color: #2a3f52;
+}
+
+.accordionButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.accordionButton:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
+  border-radius: 0.75rem;
+}
+
+.chevron {
+  flex-shrink: 0;
+  margin-left: 1rem;
+  width: 20px;
+  height: 20px;
+  color: #94a3b8;
+  transition: transform 0.3s ease;
+}
+
+.chevronExpanded {
+  transform: rotate(180deg);
+}
+
+.answerWrapper {
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  max-height: 0;
+  opacity: 0;
+}
+
+.answerWrapperExpanded {
+  max-height: 500px;
+  opacity: 1;
+}
+
+.answer {
+  padding: 0 1.5rem 1.25rem 1.5rem;
+  color: #94a3b8;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+}
+
+@media (max-width: 768px) {
+  .faqSection {
+    padding: 4rem 0;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .faqHeading {
+    font-size: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .accordionButton {
+    padding: 1rem 1.25rem;
+    font-size: 0.9375rem;
+  }
+
+  .answer {
+    padding: 0 1.25rem 1rem 1.25rem;
+    font-size: 0.875rem;
+  }
+}

--- a/src/components/Landing/FAQ.tsx
+++ b/src/components/Landing/FAQ.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import styles from './FAQ.module.css'
+
+interface FAQItem {
+  question: string
+  answer: string
+}
+
+const faqData: FAQItem[] = [
+  {
+    question: 'What is prepaid balance?',
+    answer:
+      'Prepaid balance is a credit you load into your Stellabill account in USDC on the Stellar network. Subscription charges are automatically deducted from this balance each billing cycle, so you never miss a payment.',
+  },
+  {
+    question: 'How does cancellation work?',
+    answer:
+      'You can cancel any subscription at any time from your dashboard. Once cancelled, you will retain access until the end of your current billing period. Any remaining prepaid balance can be withdrawn back to your wallet.',
+  },
+  {
+    question: 'Which wallets are supported?',
+    answer:
+      'Stellabill works with any Stellar-compatible wallet including Freighter, Lobstr, and Albedo. Users need USDC on Stellar and a small XLM reserve for transaction fees.',
+  },
+]
+
+export default function FAQ() {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(2)
+
+  const toggle = (index: number) => {
+    setExpandedIndex((prev) => (prev === index ? null : index))
+  }
+
+  return (
+    <section className={styles.faqSection} id="faq">
+      <h2 className={styles.faqHeading}>Frequently asked questions</h2>
+      <div className={styles.accordionList} role="list">
+        {faqData.map((item, index) => {
+          const isExpanded = expandedIndex === index
+          const panelId = `faq-panel-${index}`
+          const buttonId = `faq-button-${index}`
+
+          return (
+            <div
+              key={index}
+              className={styles.accordionItem}
+              role="listitem"
+            >
+              <button
+                id={buttonId}
+                className={styles.accordionButton}
+                onClick={() => toggle(index)}
+                aria-expanded={isExpanded}
+                aria-controls={panelId}
+              >
+                <span>{item.question}</span>
+                <svg
+                  className={`${styles.chevron} ${isExpanded ? styles.chevronExpanded : ''}`}
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+              <div
+                id={panelId}
+                role="region"
+                aria-labelledby={buttonId}
+                className={`${styles.answerWrapper} ${isExpanded ? styles.answerWrapperExpanded : ''}`}
+              >
+                <p className={styles.answer}>{item.answer}</p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -6,6 +6,7 @@ import FlowDiagram from '../components/Landing/FlowDiagram'
 import TechBadges from "../components/landing/TechBadges";
 import SubscriptionActions from "@/components/SubscriptionActions";
 import KeyMetrics from '@/components/Landing/KeyMetrics'
+import FAQ from "../components/Landing/FAQ";
 
 export default function Landing() {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
@@ -133,6 +134,8 @@ export default function Landing() {
             />
           </div>
         </section>
+
+          <FAQ />
 
           <section id="docs" style={{ padding: "6rem 0", minHeight: "400px" }}>
             <h2


### PR DESCRIPTION
## Description

Implements the FAQ section with an accordion component as specified in issue #39.

## Changes

- Created reusable FAQ accordion component with collapsible items
- Added dark-themed styling matching the landing page design system
- Implemented three FAQ items with the third item expanded by default
- Added smooth height transitions for expand/collapse animations
- Integrated chevron icon that rotates based on open/closed state

## Features

✅ Three FAQ items:
  - "What is prepaid balance?" (collapsed)
  - "How does cancellation work?" (collapsed)
  - "Which wallets are supported?" (expanded with full answer)

✅ Dark theme with rounded panels
✅ Responsive design (mobile-friendly)
✅ Keyboard accessibility (Enter/Space keys)
✅ ARIA attributes (aria-expanded, aria-controls)
✅ Touch-friendly tap targets
✅ Smooth animations

## Design Reference

Follows the Figma design: [Design Link](https://www.figma.com/design/TBevfcVZEuQaip9c5Yq66T/Untitled?node-id=0-1)

## Testing

- Tested expand/collapse functionality on desktop and mobile
- Verified keyboard navigation works correctly
- Confirmed ARIA attributes are properly set
- Tested styling consistency with existing dark theme

## Related Issues

Closes #39