### PR TITLE
design: density preview in Settings

### DIFF
--- a/src/__tests__/DensityPreview.test.tsx
+++ b/src/__tests__/DensityPreview.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import DensityPreview from '../components/settings/DensityPreview'
+
+describe('DensityPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-density')
+  })
+
+  it('renders three density options', () => {
+    render(<DensityPreview />)
+
+    expect(screen.getByRole('radio', { name: /compact/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /comfortable/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /spacious/i })).toBeInTheDocument()
+  })
+
+  it('defaults to comfortable density', () => {
+    render(<DensityPreview />)
+
+    const comfortableBtn = screen.getByRole('radio', { name: /comfortable/i })
+    expect(comfortableBtn).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('commits density on click and persists to localStorage', () => {
+    render(<DensityPreview />)
+
+    const compactBtn = screen.getByRole('radio', { name: /compact/i })
+    fireEvent.click(compactBtn)
+
+    expect(compactBtn).toHaveAttribute('aria-checked', 'true')
+    expect(localStorage.getItem('stellabill-density-preference')).toBe('compact')
+  })
+
+  it('triggers hover preview and reverts on mouse leave', () => {
+    render(<DensityPreview />)
+
+    const spaciousBtn = screen.getByRole('radio', { name: /spacious/i })
+    const stage = document.querySelector('.density-preview__stage') as HTMLElement
+
+    fireEvent.mouseEnter(spaciousBtn)
+    expect(stage).toHaveAttribute('data-density', 'spacious')
+
+    fireEvent.mouseLeave(spaciousBtn)
+    expect(stage).toHaveAttribute('data-density', 'comfortable')
+  })
+
+  it('hover preview does not change the committed density', () => {
+    render(<DensityPreview />)
+
+    const compactBtn = screen.getByRole('radio', { name: /compact/i })
+    const spaciousBtn = screen.getByRole('radio', { name: /spacious/i })
+
+    fireEvent.mouseEnter(spaciousBtn)
+    fireEvent.mouseLeave(spaciousBtn)
+
+    expect(compactBtn).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByRole('radio', { name: /comfortable/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('restores previously selected density from localStorage', () => {
+    localStorage.setItem('stellabill-density-preference', 'compact')
+    render(<DensityPreview />)
+
+    expect(screen.getByRole('radio', { name: /compact/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('reset restores to comfortable default', () => {
+    localStorage.setItem('stellabill-density-preference', 'spacious')
+    render(<DensityPreview />)
+
+    expect(screen.getByRole('radio', { name: /spacious/i })).toHaveAttribute('aria-checked', 'true')
+
+    const resetBtn = screen.getByRole('button', { name: /reset to default/i })
+    fireEvent.click(resetBtn)
+
+    expect(screen.getByRole('radio', { name: /comfortable/i })).toHaveAttribute('aria-checked', 'true')
+    expect(localStorage.getItem('stellabill-density-preference')).toBeNull()
+  })
+
+  it('does not show reset button when already at default', () => {
+    render(<DensityPreview />)
+
+    expect(screen.queryByRole('button', { name: /reset to default/i })).not.toBeInTheDocument()
+  })
+
+  it('has correct accessibility attributes', () => {
+    render(<DensityPreview />)
+
+    const radiogroup = screen.getByRole('radiogroup', { name: /density mode/i })
+    expect(radiogroup).toBeInTheDocument()
+
+    const radios = screen.getAllByRole('radio')
+    radios.forEach((radio) => {
+      expect(radio).toHaveAttribute('aria-checked')
+    })
+  })
+
+  it('announces density changes via aria-live region', () => {
+    render(<DensityPreview />)
+
+    const liveRegion = document.querySelector('[aria-live="polite"]') as HTMLElement
+    expect(liveRegion).toBeInTheDocument()
+
+    const compactBtn = screen.getByRole('radio', { name: /compact/i })
+    fireEvent.click(compactBtn)
+
+    expect(liveRegion.textContent).toContain('compact')
+  })
+
+  it('keyboard navigation changes focus between segments', () => {
+    render(<DensityPreview />)
+
+    const comfortableBtn = screen.getByRole('radio', { name: /comfortable/i })
+    comfortableBtn.focus()
+
+    fireEvent.keyDown(comfortableBtn, { key: 'ArrowRight' })
+
+    const spaciousBtn = screen.getByRole('radio', { name: /spacious/i })
+    expect(spaciousBtn).toHaveFocus()
+  })
+
+  it('renders preview samples (table, form, card)', () => {
+    render(<DensityPreview />)
+
+    expect(screen.getByText('Table')).toBeInTheDocument()
+    expect(screen.getByText('Form')).toBeInTheDocument()
+    expect(screen.getByText('Card')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/Settings.test.tsx
+++ b/src/__tests__/Settings.test.tsx
@@ -16,6 +16,10 @@ vi.mock('../components/settings/ApiKeysSettings', () => ({
   default: () => <div data-testid="api-keys-settings">API Keys Settings Component</div>
 }))
 
+vi.mock('../components/settings/DensityPreview', () => ({
+  default: () => <div data-testid="density-preview">Density Preview Component</div>
+}))
+
 const renderWithRouter = (component: React.ReactElement) => {
   return render(
     <BrowserRouter>
@@ -36,12 +40,14 @@ describe('Settings Page', () => {
     expect(screen.getByText(/manage your organization, billing, and security preferences/i)).toBeInTheDocument()
   })
 
-  it('displays all three main sections in navigation', () => {
+  it('displays all sections in navigation', () => {
     renderWithRouter(<Settings />)
     
     expect(screen.getByRole('button', { name: /organization/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /billing/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /api keys/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /tags/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /appearance/i })).toBeInTheDocument()
   })
 
   it('shows organization settings by default', () => {
@@ -117,7 +123,7 @@ describe('Settings Page', () => {
     expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
     
     // Check for button roles
-    expect(screen.getAllByRole('button')).toHaveLength(3) // Three navigation tabs
+    expect(screen.getAllByRole('button')).toHaveLength(5) // Five navigation tabs
   })
 })
 
@@ -159,5 +165,17 @@ describe('Settings Navigation', () => {
     // Mouse leave
     fireEvent.mouseLeave(billingTab)
     expect(billingTab).toHaveStyle('background: transparent')
+  })
+
+  it('switches to appearance settings when appearance tab is clicked', async () => {
+    renderWithRouter(<Settings />)
+    
+    const appearanceTab = screen.getByRole('button', { name: /appearance/i })
+    fireEvent.click(appearanceTab)
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('density-preview')).toBeInTheDocument()
+      expect(screen.queryByTestId('organization-settings')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/settings/DensityPreview.css
+++ b/src/components/settings/DensityPreview.css
@@ -1,0 +1,307 @@
+@import '../../styles/tokens.css';
+
+/* ── Container ── */
+.density-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.density-preview__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.density-preview__title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.density-preview__description {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+/* ── Segmented control ── */
+.density-segment {
+  display: inline-flex;
+  padding: 3px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-subtle);
+  width: fit-content;
+}
+
+.density-segment__btn {
+  border: 0;
+  padding: var(--space-2) var(--space-4);
+  border-radius: calc(var(--radius-lg) - 2px);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.density-segment__btn:hover {
+  color: var(--color-text-primary);
+}
+
+.density-segment__btn:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.density-segment__btn.is-active {
+  background: var(--color-surface-card);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ── Preview stage ── */
+.density-preview__stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap);
+  padding: var(--density-padding-inline);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-card);
+  transition: padding 200ms ease, gap 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .density-preview__stage {
+    transition: none;
+  }
+}
+
+/* ── Samples grid ── */
+.density-preview__samples {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--density-gap);
+}
+
+.density-preview__sample {
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap);
+}
+
+.density-preview__sample-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+}
+
+/* ── Table sample ── */
+.density-preview__table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.density-preview__table-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: var(--density-gap);
+  align-items: center;
+  padding: var(--density-padding-block) var(--density-padding-inline);
+  min-height: var(--density-row-height);
+  border-bottom: 1px solid var(--color-border-subtle);
+  font-size: calc(var(--text-sm) * var(--density-font-scale));
+  transition: padding 200ms ease, min-height 200ms ease, gap 200ms ease, font-size 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .density-preview__table-row {
+    transition: none;
+  }
+}
+
+.density-preview__table-row:last-child {
+  border-bottom: 0;
+}
+
+.density-preview__table-row--header {
+  background: var(--color-surface-subtle);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+.density-preview__badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.density-preview__badge--active {
+  background: var(--status-active-bg);
+  color: var(--status-active-text);
+  border: 1px solid var(--status-active-border);
+}
+
+.density-preview__badge--draft {
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-subtle);
+}
+
+/* ── Form sample ── */
+.density-preview__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap);
+}
+
+.density-preview__field {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--density-gap) * 0.5);
+}
+
+.density-preview__field-label {
+  font-size: calc(var(--text-xs) * var(--density-font-scale));
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+}
+
+.density-preview__input {
+  padding: var(--density-padding-block) var(--density-padding-inline);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-control);
+  color: var(--color-text-primary);
+  font-family: inherit;
+  font-size: calc(var(--text-sm) * var(--density-font-scale));
+  transition: padding 200ms ease, font-size 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .density-preview__input {
+    transition: none;
+  }
+}
+
+.density-preview__btn {
+  padding: var(--density-padding-block) var(--density-padding-inline);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--color-brand-primary);
+  color: var(--color-brand-on);
+  font-family: inherit;
+  font-size: calc(var(--text-sm) * var(--density-font-scale));
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: padding 200ms ease, font-size 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .density-preview__btn {
+    transition: none;
+  }
+}
+
+/* ── Card sample ── */
+.density-preview__cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--density-gap);
+}
+
+.density-preview__card {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--density-gap) * 0.5);
+  padding: var(--density-padding-block) var(--density-padding-inline);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-card);
+  transition: padding 200ms ease, gap 200ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .density-preview__card {
+    transition: none;
+  }
+}
+
+.density-preview__card-title {
+  font-size: calc(var(--text-xs) * var(--density-font-scale));
+  color: var(--color-text-muted);
+}
+
+.density-preview__card-value {
+  font-size: calc(var(--text-lg) * var(--density-font-scale));
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.density-preview__card-meta {
+  font-size: calc(var(--text-xs) * var(--density-font-scale));
+  color: var(--color-success);
+}
+
+/* ── Footer ── */
+.density-preview__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 2rem;
+}
+
+.density-preview__live {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.density-preview__reset {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-card);
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.density-preview__reset:hover {
+  background: var(--color-surface-control-hover);
+  color: var(--color-text-primary);
+}
+
+.density-preview__reset:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .density-preview__samples {
+    grid-template-columns: 1fr;
+  }
+
+  .density-preview__cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/settings/DensityPreview.tsx
+++ b/src/components/settings/DensityPreview.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useRef, useState } from 'react'
+import { RotateCcw } from 'lucide-react'
+import { useDensity, type Density } from '../../hooks/useDensity'
+import './DensityPreview.css'
+
+const DENSITY_OPTIONS: { value: Density; label: string }[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'spacious', label: 'Spacious' },
+]
+
+export default function DensityPreview() {
+  const { density, setDensity, resetDensity, isDefault } = useDensity()
+  const [previewDensity, setPreviewDensity] = useState<Density | null>(null)
+  const liveRegionRef = useRef<HTMLDivElement>(null)
+
+  const activeDensity = previewDensity ?? density
+
+  const announce = useCallback((text: string) => {
+    if (liveRegionRef.current) {
+      liveRegionRef.current.textContent = text
+    }
+  }, [])
+
+  const handleHoverEnter = useCallback(
+    (value: Density) => {
+      setPreviewDensity(value)
+      announce(`Previewing ${value} density`)
+    },
+    [announce],
+  )
+
+  const handleHoverLeave = useCallback(() => {
+    setPreviewDensity(null)
+    announce(`Restored ${density} density`)
+  }, [density, announce])
+
+  const handleSelect = useCallback(
+    (value: Density) => {
+      setDensity(value)
+      setPreviewDensity(null)
+      announce(`${value} density applied`)
+    },
+    [setDensity, announce],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, currentIndex: number) => {
+      let nextIndex = currentIndex
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault()
+        nextIndex = (currentIndex + 1) % DENSITY_OPTIONS.length
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        nextIndex = (currentIndex - 1 + DENSITY_OPTIONS.length) % DENSITY_OPTIONS.length
+      } else if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault()
+        handleSelect(DENSITY_OPTIONS[currentIndex].value)
+        return
+      } else {
+        return
+      }
+      const nextValue = DENSITY_OPTIONS[nextIndex].value
+      setPreviewDensity(nextValue)
+      announce(`Previewing ${nextValue} density`)
+      ;(e.currentTarget.parentElement?.children[nextIndex] as HTMLElement)?.focus()
+    },
+    [handleSelect, announce],
+  )
+
+  return (
+    <section className="density-preview" aria-labelledby="density-preview-heading">
+      <div className="density-preview__header">
+        <h2 id="density-preview-heading" className="density-preview__title">
+          Interface Density
+        </h2>
+        <p className="density-preview__description">
+          Choose how compact or spacious the interface feels. Hover to preview, click to commit.
+        </p>
+      </div>
+
+      <div
+        className="density-preview__stage"
+        data-density={activeDensity}
+      >
+        <div
+          className="density-segment"
+          role="radiogroup"
+          aria-label="Density mode"
+        >
+          {DENSITY_OPTIONS.map((option, index) => (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={density === option.value}
+              className={`density-segment__btn${density === option.value ? ' is-active' : ''}`}
+              onMouseEnter={() => handleHoverEnter(option.value)}
+              onMouseLeave={handleHoverLeave}
+              onFocus={() => handleHoverEnter(option.value)}
+              onBlur={handleHoverLeave}
+              onClick={() => handleSelect(option.value)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              tabIndex={density === option.value ? 0 : -1}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="density-preview__samples">
+          <div className="density-preview__sample">
+            <span className="density-preview__sample-label">Table</span>
+            <div className="density-preview__table" role="table" aria-label="Density table preview">
+              <div className="density-preview__table-row density-preview__table-row--header" role="row">
+                <span role="columnheader">Name</span>
+                <span role="columnheader">Status</span>
+                <span role="columnheader">Amount</span>
+              </div>
+              <div className="density-preview__table-row" role="row">
+                <span role="cell">Invoice #1024</span>
+                <span role="cell"><span className="density-preview__badge density-preview__badge--active">Active</span></span>
+                <span role="cell">$1,250.00</span>
+              </div>
+              <div className="density-preview__table-row" role="row">
+                <span role="cell">Invoice #1025</span>
+                <span role="cell"><span className="density-preview__badge density-preview__badge--draft">Draft</span></span>
+                <span role="cell">$890.50</span>
+              </div>
+              <div className="density-preview__table-row" role="row">
+                <span role="cell">Invoice #1026</span>
+                <span role="cell"><span className="density-preview__badge density-preview__badge--active">Active</span></span>
+                <span role="cell">$2,100.00</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="density-preview__sample">
+            <span className="density-preview__sample-label">Form</span>
+            <div className="density-preview__form">
+              <div className="density-preview__field">
+                <label className="density-preview__field-label" htmlFor="preview-name">Business name</label>
+                <input
+                  id="preview-name"
+                  className="density-preview__input"
+                  type="text"
+                  defaultValue="Acme Corp"
+                  readOnly
+                  tabIndex={-1}
+                />
+              </div>
+              <div className="density-preview__field">
+                <label className="density-preview__field-label" htmlFor="preview-email">Contact email</label>
+                <input
+                  id="preview-email"
+                  className="density-preview__input"
+                  type="email"
+                  defaultValue="admin@acme.com"
+                  readOnly
+                  tabIndex={-1}
+                />
+              </div>
+              <button
+                type="button"
+                className="density-preview__btn"
+                tabIndex={-1}
+              >
+                Save changes
+              </button>
+            </div>
+          </div>
+
+          <div className="density-preview__sample">
+            <span className="density-preview__sample-label">Card</span>
+            <div className="density-preview__cards">
+              <div className="density-preview__card">
+                <div className="density-preview__card-title">Monthly Revenue</div>
+                <div className="density-preview__card-value">$12,450</div>
+                <div className="density-preview__card-meta">+8.2% from last month</div>
+              </div>
+              <div className="density-preview__card">
+                <div className="density-preview__card-title">Active Subscriptions</div>
+                <div className="density-preview__card-value">342</div>
+                <div className="density-preview__card-meta">+12 this week</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="density-preview__footer">
+        <div
+          ref={liveRegionRef}
+          className="density-preview__live"
+          aria-live="polite"
+          aria-atomic="true"
+        />
+        {!isDefault && (
+          <button
+            type="button"
+            className="density-preview__reset"
+            onClick={resetDensity}
+          >
+            <RotateCcw size={14} aria-hidden="true" />
+            Reset to default
+          </button>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/useDensity.ts
+++ b/src/hooks/useDensity.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Density = 'compact' | 'comfortable' | 'spacious';
+const STORAGE_KEY = 'stellabill-density-preference';
+const DEFAULT_DENSITY: Density = 'comfortable';
+
+function canUseDOM() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function getStoredDensity(): Density {
+  if (!canUseDOM()) return DEFAULT_DENSITY;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === 'compact' || stored === 'comfortable' || stored === 'spacious') {
+      return stored;
+    }
+  } catch {
+    // Ignore storage failures (private mode, disabled storage, etc.)
+  }
+  return DEFAULT_DENSITY;
+}
+
+function persistDensity(density: Density) {
+  if (!canUseDOM()) return;
+
+  try {
+    if (density === DEFAULT_DENSITY) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, density);
+    }
+  } catch {
+    // Ignore storage failures
+  }
+}
+
+function applyDensity(density: Density) {
+  if (!canUseDOM()) return;
+  document.documentElement.dataset.density = density;
+}
+
+export function initializeDensity() {
+  const density = getStoredDensity();
+  applyDensity(density);
+}
+
+export function useDensity() {
+  const [density, setDensityState] = useState<Density>(() => getStoredDensity());
+
+  useEffect(() => {
+    applyDensity(density);
+    persistDensity(density);
+  }, [density]);
+
+  const setDensity = useCallback((next: Density) => {
+    setDensityState(next);
+  }, []);
+
+  const resetDensity = useCallback(() => {
+    setDensityState(DEFAULT_DENSITY);
+  }, []);
+
+  return {
+    density,
+    setDensity,
+    resetDensity,
+    isDefault: density === DEFAULT_DENSITY,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,12 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { initializeTheme } from "./hooks/useTheme";
+import { initializeDensity } from "./hooks/useDensity";
 import "./index.css";
 import "./i18n/config";
 
 initializeTheme();
+initializeDensity();
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { CreditCard, Key, Settings as SettingsIcon, Shield, Users } from 'lucide-react'
+import { CreditCard, Key, Settings as SettingsIcon, Shield, SlidersHorizontal, Tags, Users } from 'lucide-react'
 import OrganizationSettings from '../components/settings/OrganizationSettings'
 import BillingSettings from '../components/settings/BillingSettings'
 import ApiKeysSettings from '../components/settings/ApiKeysSettings'
+import DensityPreview from '../components/settings/DensityPreview'
 import './Settings.css'
 
-type SettingsTab = 'organization' | 'billing' | 'api-keys' | 'tags'
+type SettingsTab = 'organization' | 'billing' | 'api-keys' | 'tags' | 'appearance'
 
 // Wrapper component for ManageTagsSettings with state
 function ManageTagsWrapper() {
@@ -73,6 +74,13 @@ const settingsSections: SettingsSection[] = [
     icon: Tags,
     description: 'Create and manage tags for organizing plans and subscriptions',
     component: ManageTagsWrapper,
+  },
+  {
+    id: 'appearance',
+    label: 'Appearance',
+    icon: SlidersHorizontal,
+    description: 'Customize interface density and visual preferences',
+    component: DensityPreview,
   },
 ]
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -86,6 +86,25 @@
   --radius-2xl:  1.5rem;
   --radius-full: 9999px;
 
+  /* Density scale */
+  --density-compact-padding-block:   0.375rem;  /*  6px */
+  --density-compact-padding-inline:  0.5rem;    /*  8px */
+  --density-compact-gap:             0.375rem;  /*  6px */
+  --density-compact-row-height:      2rem;      /* 32px */
+  --density-compact-font-scale:      0.9;
+
+  --density-comfortable-padding-block:   0.625rem;  /* 10px */
+  --density-comfortable-padding-inline:  0.75rem;   /* 12px */
+  --density-comfortable-gap:             0.625rem;  /* 10px */
+  --density-comfortable-row-height:      2.5rem;    /* 40px */
+  --density-comfortable-font-scale:      1;
+
+  --density-spacious-padding-block:   0.875rem;  /* 14px */
+  --density-spacious-padding-inline:  1rem;      /* 16px */
+  --density-spacious-gap:             0.875rem;  /* 14px */
+  --density-spacious-row-height:      3rem;      /* 48px */
+  --density-spacious-font-scale:      1.1;
+
   /* Sidebar color tokens */
   --sidebar-bg:              #1a1a2e;
   --sidebar-width:           220px;
@@ -302,8 +321,37 @@
     --sidebar-item-active-color: #f8fafc;
     --sidebar-indicator-color: var(--color-brand-primary);
     --sidebar-group-label-color: #64748b;
-    --sidebar-focus-ring: var(--color-focus-ring);
-  }
+  --sidebar-focus-ring: var(--color-focus-ring);
+}
+
+/* ============================================================================
+   Density scope — maps generic --density-* variables to the active preset.
+   The data-density attribute on <html> selects the active preset.
+   ========================================================================== */
+[data-density="compact"] {
+  --density-padding-block:  var(--density-compact-padding-block);
+  --density-padding-inline: var(--density-compact-padding-inline);
+  --density-gap:            var(--density-compact-gap);
+  --density-row-height:     var(--density-compact-row-height);
+  --density-font-scale:     var(--density-compact-font-scale);
+}
+
+[data-density="comfortable"],
+:root:not([data-density]) {
+  --density-padding-block:  var(--density-comfortable-padding-block);
+  --density-padding-inline: var(--density-comfortable-padding-inline);
+  --density-gap:            var(--density-comfortable-gap);
+  --density-row-height:     var(--density-comfortable-row-height);
+  --density-font-scale:     var(--density-comfortable-font-scale);
+}
+
+[data-density="spacious"] {
+  --density-padding-block:  var(--density-spacious-padding-block);
+  --density-padding-inline: var(--density-spacious-padding-inline);
+  --density-gap:            var(--density-spacious-gap);
+  --density-row-height:     var(--density-spacious-row-height);
+  --density-font-scale:     var(--density-spacious-font-scale);
+}
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
## Description

Adds a density preference experience to **Settings** with a live preview panel, allowing users to compare **Compact**, **Comfortable**, and **Spacious** layouts before applying their selection.

Closes #327

## Changes

- Added a new **Appearance** section in Settings for density preferences.
- Added a three-way segmented control for **Compact**, **Comfortable**, and **Spacious** density modes.
- Added a live preview panel featuring representative:
  - Table
  - Form
  - Card
- Implemented hover/focus preview so users can explore density modes before committing.
- Added persistence for the selected density using the existing preferences pattern.
- Introduced reusable density design tokens and applied the selected density globally after confirmation.
- Added a **Reset to Default** action to restore the default density.

## Accessibility

- Keyboard-accessible segmented control with proper `radiogroup` and `radio` semantics.
- Live announcements for preview changes using `aria-live`.
- Visible focus states for keyboard users.
- Supports reduced-motion preferences.
- Responsive layout for desktop and mobile.

## Files Changed

- `src/styles/tokens.css`
- `src/hooks/useDensity.ts`
- `src/main.tsx`
- `src/components/settings/DensityPreview.tsx`
- `src/components/settings/DensityPreview.css`
- `src/pages/Settings.tsx`
- `src/__tests__/DensityPreview.test.tsx`
- `src/__tests__/Settings.test.tsx`

## Validation

- [x] 24 tests passing.
- [x `npm run lint` completed with no new lint issues.
- [x] No new TypeScript errors introduced.

## Notes

- Introduces a reusable density preference hook following the existing theme preference pattern.
- Density preview is scoped to the preview panel during hover/focus and only applied globally after the user commits a selection.
- Includes a reusable density token foundation for future UI components.
```