### PR TITLE
design: subscription reactivation flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^17.0.8",
     "react-icons": "^5.5.0",
-    "framer-motion": "^11.0.0",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/components/ReactivationModal.css
+++ b/src/components/ReactivationModal.css
@@ -1,0 +1,451 @@
+/* ReactivationModal.css
+   Subscription reactivation confirm modal.
+   Mirrors PauseSubscriptionModal visual language: dark bg, border-radius 28px,
+   modal-fade-in animation, cyan (#00CCFF) brand accent. */
+
+/* ── Overlay ─────────────────────────────────────────────────────────── */
+.reactivation-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(8px);
+  padding: 1rem;
+}
+
+/* ── Modal container ─────────────────────────────────────────────────── */
+.reactivation-modal-content {
+  background-color: #0d0d0d;
+  border-radius: 28px;
+  width: calc(100% - 2rem);
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 48px 32px 32px;
+  border: 1px solid #1a1a1a;
+  color: #ffffff;
+  box-shadow: 0 40px 100px -20px rgba(0, 0, 0, 0.7);
+  animation: reactivation-fade-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  scrollbar-width: thin;
+  scrollbar-color: #1a1a1a transparent;
+}
+
+.reactivation-modal-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.reactivation-modal-content::-webkit-scrollbar-thumb {
+  background-color: #1a1a1a;
+  border-radius: 10px;
+}
+
+@keyframes reactivation-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── Close button ────────────────────────────────────────────────────── */
+.reactivation-close-btn {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  background: transparent;
+  border: none;
+  color: #555555;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.reactivation-close-btn:hover {
+  background-color: #1a1a1a;
+  color: #ffffff;
+}
+
+.reactivation-close-btn:focus-visible {
+  outline: 2px solid #00ccff;
+  outline-offset: 2px;
+}
+
+/* ── Icon header ─────────────────────────────────────────────────────── */
+.reactivation-icon-header {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 28px;
+}
+
+.reactivation-icon-circle {
+  width: 64px;
+  height: 64px;
+  border: 4px solid #0d2a2e;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #0d0d0d;
+  color: #00ccff;
+}
+
+/* ── Title & description ─────────────────────────────────────────────── */
+.reactivation-title {
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 10px;
+  color: #ffffff;
+  letter-spacing: -0.02em;
+}
+
+.reactivation-description {
+  font-size: 15px;
+  color: #888888;
+  text-align: center;
+  margin-bottom: 28px;
+  line-height: 1.5;
+  max-width: 360px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ── Plan summary card ───────────────────────────────────────────────── */
+.reactivation-plan-card {
+  background-color: #121415;
+  border-radius: 16px;
+  padding: 20px;
+  margin-bottom: 24px;
+  border: 1px solid #1c1f20;
+}
+
+.reactivation-plan-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reactivation-plan-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.reactivation-plan-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+.reactivation-plan-interval {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0;
+}
+
+.reactivation-plan-price {
+  font-size: 20px;
+  font-weight: 700;
+  color: #00ccff;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Deleted-plan warning ────────────────────────────────────────────── */
+.reactivation-plan-deleted {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background-color: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: 10px;
+  font-size: 12px;
+  color: #f87171;
+}
+
+.reactivation-plan-deleted svg {
+  flex-shrink: 0;
+}
+
+/* ── Start-date section ──────────────────────────────────────────────── */
+.reactivation-date-section {
+  margin-bottom: 24px;
+}
+
+.reactivation-section-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 12px;
+}
+
+/* Start-date toggle pills */
+.reactivation-date-options {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.reactivation-date-opt {
+  flex: 1;
+  min-width: 130px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #1a1a1a;
+  background-color: #0a0a0a;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+}
+
+.reactivation-date-opt:hover:not(:disabled) {
+  border-color: #2a2a2a;
+  color: #e2e8f0;
+}
+
+.reactivation-date-opt[aria-pressed="true"] {
+  border-color: rgba(0, 204, 255, 0.5);
+  background-color: rgba(0, 204, 255, 0.08);
+  color: #ffffff;
+}
+
+.reactivation-date-opt:focus-visible {
+  outline: 2px solid #00ccff;
+  outline-offset: 2px;
+}
+
+.reactivation-date-opt-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.reactivation-date-opt-sub {
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+/* Custom-date picker wrapper */
+.reactivation-date-picker-wrapper {
+  margin-top: 4px;
+}
+
+/* Microcopy notice */
+.reactivation-date-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background-color: rgba(0, 204, 255, 0.05);
+  border: 1px solid rgba(0, 204, 255, 0.18);
+  border-radius: 10px;
+  margin-top: 12px;
+}
+
+.reactivation-date-notice svg {
+  flex-shrink: 0;
+  color: #00ccff;
+  margin-top: 1px;
+}
+
+.reactivation-date-notice p {
+  font-size: 12px;
+  color: #94a3b8;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ── Expired window banner ───────────────────────────────────────────── */
+.reactivation-expired-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px 16px;
+  background-color: rgba(251, 191, 36, 0.06);
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 12px;
+  margin-bottom: 24px;
+}
+
+.reactivation-expired-banner svg {
+  flex-shrink: 0;
+  color: #fbbf24;
+  margin-top: 1px;
+}
+
+.reactivation-expired-banner p {
+  font-size: 13px;
+  color: #94a3b8;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.reactivation-expired-banner strong {
+  color: #fbbf24;
+}
+
+/* ── Action buttons ──────────────────────────────────────────────────── */
+.reactivation-actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 4px;
+}
+
+.reactivation-btn {
+  flex: 1;
+  padding: 15px;
+  border-radius: 14px;
+  font-weight: 600;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.reactivation-btn-cancel {
+  background-color: #121415;
+  color: #ffffff;
+  border: 1px solid #222222;
+}
+
+.reactivation-btn-cancel:hover:not(:disabled) {
+  background-color: #1a1a1a;
+  border-color: #333333;
+}
+
+.reactivation-btn-cancel:focus-visible {
+  outline: 2px solid #00ccff;
+  outline-offset: 2px;
+}
+
+.reactivation-btn-confirm {
+  background: linear-gradient(90deg, #0099cc 0%, #00ccff 100%);
+  color: #0d0d0d;
+  font-weight: 700;
+  box-shadow: 0 10px 20px -5px rgba(0, 204, 255, 0.25);
+}
+
+.reactivation-btn-confirm:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px -5px rgba(0, 204, 255, 0.35);
+}
+
+.reactivation-btn-confirm:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.reactivation-btn-confirm:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.reactivation-btn-confirm:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* ── Loading spinner ─────────────────────────────────────────────────── */
+.reactivation-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(13, 13, 13, 0.3);
+  border-top-color: #0d0d0d;
+  border-radius: 50%;
+  animation: reactivation-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes reactivation-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Mobile ──────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .reactivation-modal-content {
+    padding: 40px 20px 24px;
+    border-radius: 24px;
+  }
+
+  .reactivation-title {
+    font-size: 24px;
+  }
+
+  .reactivation-description {
+    font-size: 14px;
+  }
+
+  .reactivation-actions {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .reactivation-date-options {
+    flex-direction: column;
+  }
+
+  .reactivation-date-opt {
+    min-width: unset;
+  }
+}
+
+/* ── RTL ─────────────────────────────────────────────────────────────── */
+[dir="rtl"] .reactivation-close-btn {
+  right: unset;
+  left: 24px;
+}
+
+[dir="rtl"] .reactivation-plan-row {
+  flex-direction: row-reverse;
+}
+
+[dir="rtl"] .reactivation-date-opt {
+  text-align: right;
+}
+
+/* ── Print ───────────────────────────────────────────────────────────── */
+@media print {
+  .reactivation-modal-overlay {
+    position: static;
+    background: none;
+    backdrop-filter: none;
+  }
+
+  .reactivation-modal-content {
+    background: #fff;
+    color: #000;
+    border: 1px solid #ccc;
+    box-shadow: none;
+    animation: none;
+  }
+}

--- a/src/components/ReactivationModal.test.tsx
+++ b/src/components/ReactivationModal.test.tsx
@@ -1,0 +1,562 @@
+/**
+ * ReactivationModal.test.tsx
+ *
+ * Tests cover:
+ * - Basic rendering (open/closed, plan summary, icon, heading)
+ * - Start-date options: "Start today", "Same billing day", "Custom date"
+ * - Same-billing-day visibility (hidden when billing day === today)
+ * - Custom date calendar renders and date selection works
+ * - Microcopy updates with each mode
+ * - Confirm button disabled states (plan deleted, window expired, custom without date)
+ * - onConfirm called with correct date for each mode
+ * - Loading state (spinner, button label)
+ * - Deleted-plan warning (role=alert)
+ * - Expired-window banner (role=alert, blocks confirm)
+ * - Close via button, overlay click, and Escape key
+ * - Focus management (initial focus on "Keep cancelled" button)
+ * - Accessibility: role=dialog, aria-modal, aria-labelledby, aria-describedby,
+ *   aria-pressed on date options, all SVGs aria-hidden
+ * - RTL: renders without errors inside dir=rtl container
+ * - State resets on close/reopen
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReactivationModal, { type ReactivationPlan } from './ReactivationModal';
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+const PLAN: ReactivationPlan = {
+  name: 'Pro Monthly',
+  interval: 'Monthly',
+  price: '50 USDC',
+  deleted: false,
+};
+
+const DELETED_PLAN: ReactivationPlan = {
+  ...PLAN,
+  deleted: true,
+};
+
+function renderModal(
+  overrides: Partial<Parameters<typeof ReactivationModal>[0]> = {}
+) {
+  const onClose = vi.fn();
+  const onConfirm = vi.fn();
+  const result = render(
+    <ReactivationModal
+      isOpen={true}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      plan={PLAN}
+      billingDay={15}
+      {...overrides}
+      // Spread after so caller can override onClose/onConfirm too
+    />
+  );
+  return { onClose, onConfirm, container: result.container };
+}
+
+// ── Basic rendering ──────────────────────────────────────────────────────────
+
+describe('ReactivationModal – basic rendering', () => {
+  it('renders nothing when isOpen=false', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={false}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the modal when isOpen=true', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('renders the heading', () => {
+    renderModal();
+    expect(
+      screen.getByRole('heading', { name: /reactivate subscription/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the plan name', () => {
+    renderModal();
+    expect(screen.getAllByText('Pro Monthly').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the plan interval', () => {
+    renderModal();
+    expect(screen.getByText('Monthly')).toBeInTheDocument();
+  });
+
+  it('renders the plan price', () => {
+    renderModal();
+    expect(screen.getByText('50 USDC')).toBeInTheDocument();
+  });
+
+  it('renders the keep-cancelled and reactivate buttons', () => {
+    renderModal();
+    expect(
+      screen.getByRole('button', { name: /keep cancelled/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /confirm reactivation|reactivate/i })
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Accessibility ────────────────────────────────────────────────────────────
+
+describe('ReactivationModal – accessibility', () => {
+  it('has role=dialog and aria-modal=true', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('dialog is labelled by the heading', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'reactivation-modal-title');
+    expect(
+      document.getElementById('reactivation-modal-title')
+    ).toBeInTheDocument();
+  });
+
+  it('dialog has aria-describedby pointing at the description', () => {
+    renderModal();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'reactivation-modal-description');
+    expect(
+      document.getElementById('reactivation-modal-description')
+    ).toBeInTheDocument();
+  });
+
+  it('all SVG icons are aria-hidden', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+      />
+    );
+    container.querySelectorAll('svg').forEach(svg => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('close button has descriptive aria-label', () => {
+    renderModal();
+    expect(
+      screen.getByRole('button', { name: /close reactivation dialog/i })
+    ).toBeInTheDocument();
+  });
+
+  it('date option buttons have aria-pressed', () => {
+    const { container } = renderModal();
+    const opts = container.querySelectorAll('.reactivation-date-opt');
+    opts.forEach(opt => {
+      expect(opt).toHaveAttribute('aria-pressed');
+    });
+  });
+
+  it('"Start today" option is pressed by default', () => {
+    renderModal();
+    const todayBtn = screen.getByRole('button', { name: /start today/i });
+    expect(todayBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('date options group has aria-labelledby', () => {
+    const { container } = renderModal();
+    const group = container.querySelector('[role="group"]');
+    expect(group).toHaveAttribute('aria-labelledby', 'reactivation-date-label');
+  });
+
+  it('time elements have dateTime attributes', () => {
+    const { container } = renderModal();
+    const timeEls = container.querySelectorAll('time');
+    timeEls.forEach(el => {
+      expect(el.getAttribute('dateTime')).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    });
+  });
+});
+
+// ── Close behaviour ──────────────────────────────────────────────────────────
+
+describe('ReactivationModal – closing', () => {
+  it('calls onClose when close button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByRole('button', { name: /close reactivation dialog/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when "Keep cancelled" button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderModal();
+    await user.click(screen.getByRole('button', { name: /keep cancelled/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when overlay backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={onClose}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+      />
+    );
+    // Click the overlay (first child of the portal)
+    const overlay = container.querySelector('.reactivation-modal-overlay');
+    expect(overlay).toBeInTheDocument();
+    fireEvent.click(overlay!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Start-date options ───────────────────────────────────────────────────────
+
+describe('ReactivationModal – start-date modes', () => {
+  it('defaults to "Start today" mode', () => {
+    renderModal();
+    const todayBtn = screen.getByRole('button', { name: /start today/i });
+    expect(todayBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows "Same billing day" option when billingDay !== today', () => {
+    // billingDay=15 will almost always differ from today's day
+    renderModal({ billingDay: 15 });
+    expect(
+      screen.getByRole('button', { name: /same billing day/i })
+    ).toBeInTheDocument();
+  });
+
+  it('selecting "Same billing day" updates aria-pressed', async () => {
+    const user = userEvent.setup();
+    renderModal({ billingDay: 15 });
+    const billingDayBtn = screen.getByRole('button', { name: /same billing day/i });
+    await user.click(billingDayBtn);
+    expect(billingDayBtn).toHaveAttribute('aria-pressed', 'true');
+    // "Start today" should no longer be pressed
+    expect(
+      screen.getByRole('button', { name: /start today/i })
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selecting "Custom date" shows the calendar', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: /custom date/i }));
+    expect(screen.getByRole('application')).toBeInTheDocument(); // DatePickerCalendar
+  });
+
+  it('selecting "Start today" hides the calendar', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    // first open calendar
+    await user.click(screen.getByRole('button', { name: /custom date/i }));
+    expect(screen.getByRole('application')).toBeInTheDocument();
+    // then switch back
+    await user.click(screen.getByRole('button', { name: /start today/i }));
+    expect(screen.queryByRole('application')).not.toBeInTheDocument();
+  });
+});
+
+// ── Microcopy ────────────────────────────────────────────────────────────────
+
+describe('ReactivationModal – microcopy', () => {
+  it('shows "today" microcopy in default mode', () => {
+    renderModal();
+    const note = screen.getByRole('note');
+    expect(within(note).getByText(/Access and billing begin today/i)).toBeInTheDocument();
+  });
+
+  it('shows billing-day microcopy when billing-day mode is selected', async () => {
+    const user = userEvent.setup();
+    renderModal({ billingDay: 15 });
+    await user.click(screen.getByRole('button', { name: /same billing day/i }));
+    const note = screen.getByRole('note');
+    expect(within(note).getByText(/billing cycle will reset to day 15/i)).toBeInTheDocument();
+  });
+
+  it('shows "pick a date" text for custom mode before date selected', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: /custom date/i }));
+    expect(screen.getByText(/pick a date/i)).toBeInTheDocument();
+  });
+});
+
+// ── Confirm button state ─────────────────────────────────────────────────────
+
+describe('ReactivationModal – confirm button', () => {
+  it('is enabled in default (today) mode', () => {
+    renderModal();
+    const btn = screen.getByRole('button', { name: /confirm reactivation|reactivate/i });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('is disabled in custom mode until a date is picked', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: /custom date/i }));
+    const btn = screen.getByRole('button', { name: /confirm reactivation|reactivate/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('is disabled when plan is deleted', () => {
+    renderModal({ plan: DELETED_PLAN });
+    const btn = screen.getByRole('button', { name: /confirm reactivation|reactivate/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('is disabled when window is expired', () => {
+    renderModal({ windowExpired: true });
+    const btn = screen.getByRole('button', { name: /confirm reactivation|reactivate/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('is disabled when isLoading=true', () => {
+    renderModal({ isLoading: true });
+    const btn = screen.getByRole('button', { name: /reactivating|please wait/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('calls onConfirm with today\'s date in "today" mode', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+        plan={PLAN}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /confirm reactivation|^reactivate$/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const calledDate: Date = onConfirm.mock.calls[0][0];
+    const now = new Date();
+    expect(calledDate.getFullYear()).toBe(now.getFullYear());
+    expect(calledDate.getMonth()).toBe(now.getMonth());
+    expect(calledDate.getDate()).toBe(now.getDate());
+  });
+});
+
+// ── Loading state ────────────────────────────────────────────────────────────
+
+describe('ReactivationModal – loading state', () => {
+  it('shows spinner text when loading', () => {
+    renderModal({ isLoading: true });
+    expect(screen.getByText(/reactivating/i)).toBeInTheDocument();
+  });
+
+  it('renders spinner element when loading', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        isLoading={true}
+      />
+    );
+    expect(container.querySelector('.reactivation-spinner')).toBeInTheDocument();
+  });
+
+  it('"Keep cancelled" button is disabled when loading', () => {
+    renderModal({ isLoading: true });
+    expect(
+      screen.getByRole('button', { name: /keep cancelled/i })
+    ).toBeDisabled();
+  });
+});
+
+// ── Deleted-plan edge case ───────────────────────────────────────────────────
+
+describe('ReactivationModal – deleted plan', () => {
+  it('shows deleted-plan alert', () => {
+    renderModal({ plan: DELETED_PLAN });
+    expect(
+      screen.getByText(/plan is no longer available/i)
+    ).toBeInTheDocument();
+  });
+
+  it('deleted alert has role=alert', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={DELETED_PLAN}
+      />
+    );
+    const alerts = container.querySelectorAll('[role="alert"]');
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('date option buttons are disabled when plan is deleted', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={DELETED_PLAN}
+      />
+    );
+    const opts = container.querySelectorAll('.reactivation-date-opt');
+    opts.forEach(opt => {
+      expect(opt).toBeDisabled();
+    });
+  });
+});
+
+// ── Expired window edge case ─────────────────────────────────────────────────
+
+describe('ReactivationModal – expired reactivation window', () => {
+  it('shows expired-window banner', () => {
+    renderModal({ windowExpired: true });
+    expect(screen.getByText(/reactivation window has expired/i)).toBeInTheDocument();
+  });
+
+  it('expired banner has role=alert', () => {
+    renderModal({ windowExpired: true });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('date option buttons are disabled when window is expired', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        windowExpired={true}
+      />
+    );
+    const opts = container.querySelectorAll('.reactivation-date-opt');
+    opts.forEach(opt => {
+      expect(opt).toBeDisabled();
+    });
+  });
+});
+
+// ── State reset on reopen ────────────────────────────────────────────────────
+
+describe('ReactivationModal – state resets on close/reopen', () => {
+  it('resets mode to "today" when reopened', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        billingDay={15}
+      />
+    );
+    // Switch to billing-day mode
+    await user.click(screen.getByRole('button', { name: /same billing day/i }));
+    expect(
+      screen.getByRole('button', { name: /same billing day/i })
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    // Close then reopen
+    rerender(
+      <ReactivationModal
+        isOpen={false}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        billingDay={15}
+      />
+    );
+    rerender(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        billingDay={15}
+      />
+    );
+
+    // Should be back to "today" mode
+    expect(
+      screen.getByRole('button', { name: /start today/i })
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+// ── RTL ──────────────────────────────────────────────────────────────────────
+
+describe('ReactivationModal – RTL layout', () => {
+  it('renders without errors inside a dir=rtl container', () => {
+    const { container } = render(
+      <div dir="rtl">
+        <ReactivationModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onConfirm={vi.fn()}
+          plan={PLAN}
+          billingDay={15}
+        />
+      </div>
+    );
+    expect(
+      container.querySelector('.reactivation-modal-content')
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Snapshot ─────────────────────────────────────────────────────────────────
+
+describe('ReactivationModal – snapshot', () => {
+  it('matches snapshot for standard open state', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        billingDay={15}
+        windowExpired={false}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for expired window', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={PLAN}
+        windowExpired={true}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for deleted plan', () => {
+    const { container } = render(
+      <ReactivationModal
+        isOpen={true}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        plan={DELETED_PLAN}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/ReactivationModal.tsx
+++ b/src/components/ReactivationModal.tsx
@@ -1,0 +1,442 @@
+/**
+ * ReactivationModal
+ *
+ * Confirm modal for reactivating a previously cancelled subscription.
+ * Surfaces only when reactivation is possible within the support window
+ * (planDeleted=false AND windowExpired=false).
+ *
+ * Features
+ * ─────────
+ * • Plan summary card (name, interval, price)
+ * • Start-date picker: "Start today" | "Same billing day" | "Custom date"
+ * • Microcopy explaining billing-day rounding
+ * • Deleted-plan warning (read-only, blocks confirm)
+ * • Expired-window banner (read-only, blocks confirm)
+ * • Full keyboard nav + focus trap via useModalFocus
+ * • WCAG 2.1 AA: role=dialog, aria-modal, aria-labelledby/describedby,
+ *   aria-pressed on date options, aria-live loading state, all icons aria-hidden
+ * • Responsive: single-column on mobile
+ * • RTL-safe
+ */
+
+import { useRef, MouseEvent, useState, useEffect } from 'react';
+import { useModalFocus } from '../hooks/useModalFocus';
+import DatePickerCalendar from './DatePickerCalendar';
+import './ReactivationModal.css';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type StartDateMode = 'today' | 'billing-day' | 'custom';
+
+export interface ReactivationPlan {
+  /** Human-readable plan name, e.g. "Pro Monthly" */
+  name: string;
+  /** Billing interval label, e.g. "Monthly" */
+  interval: string;
+  /** Formatted price string, e.g. "50 USDC" */
+  price: string;
+  /**
+   * Whether the plan has been deleted and can no longer be subscribed to.
+   * When true, the Reactivate button is disabled and a warning is shown.
+   */
+  deleted?: boolean;
+}
+
+export interface ReactivationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Called with the chosen start date when the user confirms reactivation.
+   * The parent is responsible for the API call.
+   */
+  onConfirm: (startDate: Date) => void;
+  /** Details of the plan being reactivated */
+  plan: ReactivationPlan;
+  /**
+   * Whether the reactivation support window has expired.
+   * When true, the Reactivate button is disabled.
+   */
+  windowExpired?: boolean;
+  /**
+   * The subscriber's original monthly billing day (1–28).
+   * Used to compute the "Same billing day" option.
+   * Defaults to the 1st if omitted.
+   */
+  billingDay?: number;
+  /** Shows a loading spinner in the confirm button while the API call is in flight */
+  isLoading?: boolean;
+  /**
+   * Maximum number of days ahead the user can pick for a custom start date.
+   * Defaults to 90.
+   */
+  maxDaysAhead?: number;
+}
+
+// ── Date helpers ─────────────────────────────────────────────────────────────
+
+/** Today at midnight local time */
+function today(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Next occurrence of `billingDay` at or after today.
+ * Clamps to day 28 to avoid month-length edge cases.
+ */
+function nextBillingDayDate(billingDay: number): Date {
+  const day = Math.min(Math.max(billingDay, 1), 28);
+  const now = today();
+  const candidate = new Date(now.getFullYear(), now.getMonth(), day);
+  if (candidate < now) {
+    candidate.setMonth(candidate.getMonth() + 1);
+  }
+  return candidate;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function toIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function ReactivationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  plan,
+  windowExpired = false,
+  billingDay = 1,
+  isLoading = false,
+  maxDaysAhead = 90,
+}: ReactivationModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const initialFocusRef = useRef<HTMLButtonElement>(null);
+
+  const [mode, setMode] = useState<StartDateMode>('today');
+  const [customDate, setCustomDate] = useState<Date | null>(null);
+
+  // Reset state each time the modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setMode('today');
+      setCustomDate(null);
+    }
+  }, [isOpen]);
+
+  useModalFocus(modalRef, { isOpen, onClose, initialFocusRef });
+
+  if (!isOpen) return null;
+
+  // ── Derived state ──────────────────────────────────────────────────────────
+
+  const todayDate = today();
+  const billingDayDate = nextBillingDayDate(billingDay);
+  const isSameDayAsBillingDay = toIso(todayDate) === toIso(billingDayDate);
+
+  const maxDate = new Date(todayDate);
+  maxDate.setDate(maxDate.getDate() + maxDaysAhead);
+
+  const resolvedStartDate: Date =
+    mode === 'today'
+      ? todayDate
+      : mode === 'billing-day'
+      ? billingDayDate
+      : (customDate ?? todayDate);
+
+  const canConfirm =
+    !plan.deleted &&
+    !windowExpired &&
+    !isLoading &&
+    (mode !== 'custom' || customDate !== null);
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const handleConfirm = () => {
+    if (!canConfirm) return;
+    onConfirm(resolvedStartDate);
+  };
+
+  // ── Microcopy ──────────────────────────────────────────────────────────────
+
+  const dateNotice =
+    mode === 'billing-day'
+      ? `Your billing cycle will reset to day ${billingDay} of each month. Any gap from today is unpaid — access starts on ${formatDate(billingDayDate)}.`
+      : mode === 'custom' && customDate
+      ? `Access and billing begin on ${formatDate(customDate)}.`
+      : `Access and billing begin today, ${formatDate(todayDate)}.`;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      className="reactivation-modal-overlay"
+      onClick={(e: MouseEvent<HTMLDivElement>) =>
+        e.target === e.currentTarget && onClose()
+      }
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reactivation-modal-title"
+      aria-describedby="reactivation-modal-description"
+    >
+      <div className="reactivation-modal-content" ref={modalRef}>
+        {/* Close */}
+        <button
+          className="reactivation-close-btn"
+          onClick={onClose}
+          aria-label="Close reactivation dialog"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+
+        {/* Icon */}
+        <div className="reactivation-icon-header" aria-hidden="true">
+          <div className="reactivation-icon-circle">
+            <svg
+              width="26"
+              height="26"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#00ccff"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              {/* Circular arrow — "refresh / reactivate" */}
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+          </div>
+        </div>
+
+        {/* Heading & description */}
+        <h2 id="reactivation-modal-title" className="reactivation-title">
+          Reactivate subscription?
+        </h2>
+        <p
+          id="reactivation-modal-description"
+          className="reactivation-description"
+        >
+          Restore your{' '}
+          <strong style={{ color: '#e2e8f0' }}>{plan.name}</strong> plan with
+          the same settings. Choose when billing should restart.
+        </p>
+
+        {/* ── Expired window banner ──────────────────────────────────────── */}
+        {windowExpired && (
+          <div className="reactivation-expired-banner" role="alert">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p>
+              <strong>Reactivation window has expired.</strong> It has been
+              too long since this subscription was cancelled. Please{' '}
+              <strong>browse plans</strong> to start a new subscription.
+            </p>
+          </div>
+        )}
+
+        {/* ── Plan summary card ──────────────────────────────────────────── */}
+        <div className="reactivation-plan-card" aria-label="Plan summary">
+          <div className="reactivation-plan-row">
+            <div className="reactivation-plan-info">
+              <p className="reactivation-plan-name">{plan.name}</p>
+              <p className="reactivation-plan-interval">{plan.interval}</p>
+            </div>
+            <span className="reactivation-plan-price">{plan.price}</span>
+          </div>
+
+          {plan.deleted && (
+            <div className="reactivation-plan-deleted" role="alert">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="15" y1="9" x2="9" y2="15" />
+                <line x1="9" y1="9" x2="15" y2="15" />
+              </svg>
+              This plan is no longer available. Reactivation is not possible.
+            </div>
+          )}
+        </div>
+
+        {/* ── Start date section ─────────────────────────────────────────── */}
+        <div className="reactivation-date-section">
+          <p className="reactivation-section-label" id="reactivation-date-label">
+            Start date
+          </p>
+
+          {/* Option buttons */}
+          <div
+            className="reactivation-date-options"
+            role="group"
+            aria-labelledby="reactivation-date-label"
+          >
+            {/* Today */}
+            <button
+              className="reactivation-date-opt"
+              aria-pressed={mode === 'today'}
+              onClick={() => setMode('today')}
+              disabled={windowExpired || plan.deleted}
+            >
+              <span className="reactivation-date-opt-title">Start today</span>
+              <span className="reactivation-date-opt-sub">
+                <time dateTime={toIso(todayDate)}>{formatDate(todayDate)}</time>
+              </span>
+            </button>
+
+            {/* Same billing day (only shown when it differs from today) */}
+            {!isSameDayAsBillingDay && (
+              <button
+                className="reactivation-date-opt"
+                aria-pressed={mode === 'billing-day'}
+                onClick={() => setMode('billing-day')}
+                disabled={windowExpired || plan.deleted}
+              >
+                <span className="reactivation-date-opt-title">
+                  Same billing day
+                </span>
+                <span className="reactivation-date-opt-sub">
+                  Day {billingDay} ·{' '}
+                  <time dateTime={toIso(billingDayDate)}>
+                    {formatDate(billingDayDate)}
+                  </time>
+                </span>
+              </button>
+            )}
+
+            {/* Custom */}
+            <button
+              className="reactivation-date-opt"
+              aria-pressed={mode === 'custom'}
+              onClick={() => setMode('custom')}
+              disabled={windowExpired || plan.deleted}
+            >
+              <span className="reactivation-date-opt-title">Custom date</span>
+              <span className="reactivation-date-opt-sub">
+                {customDate ? (
+                  <time dateTime={toIso(customDate)}>
+                    {formatDate(customDate)}
+                  </time>
+                ) : (
+                  'Pick a date'
+                )}
+              </span>
+            </button>
+          </div>
+
+          {/* Calendar (only when custom mode is active) */}
+          {mode === 'custom' && (
+            <div className="reactivation-date-picker-wrapper">
+              <DatePickerCalendar
+                selectedDate={customDate}
+                onDateSelect={(d) => setCustomDate(d)}
+                minDate={todayDate}
+                maxDate={maxDate}
+              />
+            </div>
+          )}
+
+          {/* Microcopy */}
+          <div className="reactivation-date-notice" role="note">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p>{dateNotice}</p>
+          </div>
+        </div>
+
+        {/* ── Actions ────────────────────────────────────────────────────── */}
+        <div className="reactivation-actions">
+          <button
+            ref={initialFocusRef}
+            className="reactivation-btn reactivation-btn-cancel"
+            onClick={onClose}
+            disabled={isLoading}
+          >
+            Keep cancelled
+          </button>
+          <button
+            className="reactivation-btn reactivation-btn-confirm"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            aria-disabled={!canConfirm}
+            aria-live="polite"
+            aria-label={
+              isLoading
+                ? 'Reactivating subscription, please wait'
+                : 'Confirm reactivation'
+            }
+          >
+            {isLoading ? (
+              <>
+                <span className="reactivation-spinner" aria-hidden="true" />
+                Reactivating…
+              </>
+            ) : (
+              'Reactivate'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__snapshots__/ReactivationModal.test.tsx.snap
+++ b/src/components/__snapshots__/ReactivationModal.test.tsx.snap
@@ -1,0 +1,824 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ReactivationModal – snapshot > matches snapshot for deleted plan 1`] = `
+<div
+  aria-describedby="reactivation-modal-description"
+  aria-labelledby="reactivation-modal-title"
+  aria-modal="true"
+  class="reactivation-modal-overlay"
+  role="dialog"
+>
+  <div
+    class="reactivation-modal-content"
+  >
+    <button
+      aria-label="Close reactivation dialog"
+      class="reactivation-close-btn"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="20"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="20"
+      >
+        <line
+          x1="18"
+          x2="6"
+          y1="6"
+          y2="18"
+        />
+        <line
+          x1="6"
+          x2="18"
+          y1="6"
+          y2="18"
+        />
+      </svg>
+    </button>
+    <div
+      aria-hidden="true"
+      class="reactivation-icon-header"
+    >
+      <div
+        class="reactivation-icon-circle"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="26"
+          stroke="#00ccff"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2.2"
+          viewBox="0 0 24 24"
+          width="26"
+        >
+          <polyline
+            points="23 4 23 10 17 10"
+          />
+          <path
+            d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"
+          />
+        </svg>
+      </div>
+    </div>
+    <h2
+      class="reactivation-title"
+      id="reactivation-modal-title"
+    >
+      Reactivate subscription?
+    </h2>
+    <p
+      class="reactivation-description"
+      id="reactivation-modal-description"
+    >
+      Restore your
+       
+      <strong
+        style="color: rgb(226, 232, 240);"
+      >
+        Pro Monthly
+      </strong>
+       plan with the same settings. Choose when billing should restart.
+    </p>
+    <div
+      aria-label="Plan summary"
+      class="reactivation-plan-card"
+    >
+      <div
+        class="reactivation-plan-row"
+      >
+        <div
+          class="reactivation-plan-info"
+        >
+          <p
+            class="reactivation-plan-name"
+          >
+            Pro Monthly
+          </p>
+          <p
+            class="reactivation-plan-interval"
+          >
+            Monthly
+          </p>
+        </div>
+        <span
+          class="reactivation-plan-price"
+        >
+          50 USDC
+        </span>
+      </div>
+      <div
+        class="reactivation-plan-deleted"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="15"
+            x2="9"
+            y1="9"
+            y2="15"
+          />
+          <line
+            x1="9"
+            x2="15"
+            y1="9"
+            y2="15"
+          />
+        </svg>
+        This plan is no longer available. Reactivation is not possible.
+      </div>
+    </div>
+    <div
+      class="reactivation-date-section"
+    >
+      <p
+        class="reactivation-section-label"
+        id="reactivation-date-label"
+      >
+        Start date
+      </p>
+      <div
+        aria-labelledby="reactivation-date-label"
+        class="reactivation-date-options"
+        role="group"
+      >
+        <button
+          aria-pressed="true"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Start today
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            <time
+              datetime="2026-07-28"
+            >
+              Jul 28, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Same billing day
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Day 
+            1
+             ·
+             
+            <time
+              datetime="2026-08-01"
+            >
+              Aug 1, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Custom date
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Pick a date
+          </span>
+        </button>
+      </div>
+      <div
+        class="reactivation-date-notice"
+        role="note"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="8"
+            y2="12"
+          />
+          <line
+            x1="12"
+            x2="12.01"
+            y1="16"
+            y2="16"
+          />
+        </svg>
+        <p>
+          Access and billing begin today, Jul 28, 2026.
+        </p>
+      </div>
+    </div>
+    <div
+      class="reactivation-actions"
+    >
+      <button
+        class="reactivation-btn reactivation-btn-cancel"
+      >
+        Keep cancelled
+      </button>
+      <button
+        aria-disabled="true"
+        aria-label="Confirm reactivation"
+        aria-live="polite"
+        class="reactivation-btn reactivation-btn-confirm"
+        disabled=""
+      >
+        Reactivate
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ReactivationModal – snapshot > matches snapshot for expired window 1`] = `
+<div
+  aria-describedby="reactivation-modal-description"
+  aria-labelledby="reactivation-modal-title"
+  aria-modal="true"
+  class="reactivation-modal-overlay"
+  role="dialog"
+>
+  <div
+    class="reactivation-modal-content"
+  >
+    <button
+      aria-label="Close reactivation dialog"
+      class="reactivation-close-btn"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="20"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="20"
+      >
+        <line
+          x1="18"
+          x2="6"
+          y1="6"
+          y2="18"
+        />
+        <line
+          x1="6"
+          x2="18"
+          y1="6"
+          y2="18"
+        />
+      </svg>
+    </button>
+    <div
+      aria-hidden="true"
+      class="reactivation-icon-header"
+    >
+      <div
+        class="reactivation-icon-circle"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="26"
+          stroke="#00ccff"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2.2"
+          viewBox="0 0 24 24"
+          width="26"
+        >
+          <polyline
+            points="23 4 23 10 17 10"
+          />
+          <path
+            d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"
+          />
+        </svg>
+      </div>
+    </div>
+    <h2
+      class="reactivation-title"
+      id="reactivation-modal-title"
+    >
+      Reactivate subscription?
+    </h2>
+    <p
+      class="reactivation-description"
+      id="reactivation-modal-description"
+    >
+      Restore your
+       
+      <strong
+        style="color: rgb(226, 232, 240);"
+      >
+        Pro Monthly
+      </strong>
+       plan with the same settings. Choose when billing should restart.
+    </p>
+    <div
+      class="reactivation-expired-banner"
+      role="alert"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="16"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <p>
+        <strong>
+          Reactivation window has expired.
+        </strong>
+         It has been too long since this subscription was cancelled. Please
+         
+        <strong>
+          browse plans
+        </strong>
+         to start a new subscription.
+      </p>
+    </div>
+    <div
+      aria-label="Plan summary"
+      class="reactivation-plan-card"
+    >
+      <div
+        class="reactivation-plan-row"
+      >
+        <div
+          class="reactivation-plan-info"
+        >
+          <p
+            class="reactivation-plan-name"
+          >
+            Pro Monthly
+          </p>
+          <p
+            class="reactivation-plan-interval"
+          >
+            Monthly
+          </p>
+        </div>
+        <span
+          class="reactivation-plan-price"
+        >
+          50 USDC
+        </span>
+      </div>
+    </div>
+    <div
+      class="reactivation-date-section"
+    >
+      <p
+        class="reactivation-section-label"
+        id="reactivation-date-label"
+      >
+        Start date
+      </p>
+      <div
+        aria-labelledby="reactivation-date-label"
+        class="reactivation-date-options"
+        role="group"
+      >
+        <button
+          aria-pressed="true"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Start today
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            <time
+              datetime="2026-07-28"
+            >
+              Jul 28, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Same billing day
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Day 
+            1
+             ·
+             
+            <time
+              datetime="2026-08-01"
+            >
+              Aug 1, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+          disabled=""
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Custom date
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Pick a date
+          </span>
+        </button>
+      </div>
+      <div
+        class="reactivation-date-notice"
+        role="note"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="8"
+            y2="12"
+          />
+          <line
+            x1="12"
+            x2="12.01"
+            y1="16"
+            y2="16"
+          />
+        </svg>
+        <p>
+          Access and billing begin today, Jul 28, 2026.
+        </p>
+      </div>
+    </div>
+    <div
+      class="reactivation-actions"
+    >
+      <button
+        class="reactivation-btn reactivation-btn-cancel"
+      >
+        Keep cancelled
+      </button>
+      <button
+        aria-disabled="true"
+        aria-label="Confirm reactivation"
+        aria-live="polite"
+        class="reactivation-btn reactivation-btn-confirm"
+        disabled=""
+      >
+        Reactivate
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ReactivationModal – snapshot > matches snapshot for standard open state 1`] = `
+<div
+  aria-describedby="reactivation-modal-description"
+  aria-labelledby="reactivation-modal-title"
+  aria-modal="true"
+  class="reactivation-modal-overlay"
+  role="dialog"
+>
+  <div
+    class="reactivation-modal-content"
+  >
+    <button
+      aria-label="Close reactivation dialog"
+      class="reactivation-close-btn"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="20"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="20"
+      >
+        <line
+          x1="18"
+          x2="6"
+          y1="6"
+          y2="18"
+        />
+        <line
+          x1="6"
+          x2="18"
+          y1="6"
+          y2="18"
+        />
+      </svg>
+    </button>
+    <div
+      aria-hidden="true"
+      class="reactivation-icon-header"
+    >
+      <div
+        class="reactivation-icon-circle"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="26"
+          stroke="#00ccff"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2.2"
+          viewBox="0 0 24 24"
+          width="26"
+        >
+          <polyline
+            points="23 4 23 10 17 10"
+          />
+          <path
+            d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"
+          />
+        </svg>
+      </div>
+    </div>
+    <h2
+      class="reactivation-title"
+      id="reactivation-modal-title"
+    >
+      Reactivate subscription?
+    </h2>
+    <p
+      class="reactivation-description"
+      id="reactivation-modal-description"
+    >
+      Restore your
+       
+      <strong
+        style="color: rgb(226, 232, 240);"
+      >
+        Pro Monthly
+      </strong>
+       plan with the same settings. Choose when billing should restart.
+    </p>
+    <div
+      aria-label="Plan summary"
+      class="reactivation-plan-card"
+    >
+      <div
+        class="reactivation-plan-row"
+      >
+        <div
+          class="reactivation-plan-info"
+        >
+          <p
+            class="reactivation-plan-name"
+          >
+            Pro Monthly
+          </p>
+          <p
+            class="reactivation-plan-interval"
+          >
+            Monthly
+          </p>
+        </div>
+        <span
+          class="reactivation-plan-price"
+        >
+          50 USDC
+        </span>
+      </div>
+    </div>
+    <div
+      class="reactivation-date-section"
+    >
+      <p
+        class="reactivation-section-label"
+        id="reactivation-date-label"
+      >
+        Start date
+      </p>
+      <div
+        aria-labelledby="reactivation-date-label"
+        class="reactivation-date-options"
+        role="group"
+      >
+        <button
+          aria-pressed="true"
+          class="reactivation-date-opt"
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Start today
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            <time
+              datetime="2026-07-28"
+            >
+              Jul 28, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Same billing day
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Day 
+            15
+             ·
+             
+            <time
+              datetime="2026-08-15"
+            >
+              Aug 15, 2026
+            </time>
+          </span>
+        </button>
+        <button
+          aria-pressed="false"
+          class="reactivation-date-opt"
+        >
+          <span
+            class="reactivation-date-opt-title"
+          >
+            Custom date
+          </span>
+          <span
+            class="reactivation-date-opt-sub"
+          >
+            Pick a date
+          </span>
+        </button>
+      </div>
+      <div
+        class="reactivation-date-notice"
+        role="note"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="8"
+            y2="12"
+          />
+          <line
+            x1="12"
+            x2="12.01"
+            y1="16"
+            y2="16"
+          />
+        </svg>
+        <p>
+          Access and billing begin today, Jul 28, 2026.
+        </p>
+      </div>
+    </div>
+    <div
+      class="reactivation-actions"
+    >
+      <button
+        class="reactivation-btn reactivation-btn-cancel"
+      >
+        Keep cancelled
+      </button>
+      <button
+        aria-disabled="false"
+        aria-label="Confirm reactivation"
+        aria-live="polite"
+        class="reactivation-btn reactivation-btn-confirm"
+      >
+        Reactivate
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/SubscriptionDetail.tsx
+++ b/src/pages/SubscriptionDetail.tsx
@@ -4,53 +4,191 @@ import RecentPayments from '../components/RecentPayments';
 import UsageThisPeriod from '../components/UsageThisPeriod';
 import PaymentFailedBanner from '../components/Dunning/PaymentFailedBanner';
 import PlanStatusTimeline from '../components/PlanStatusTimeline';
+import ScheduleChangePreview, { type BillingInterval } from '../components/ScheduleChangePreview';
+import ReactivationModal, { type ReactivationPlan } from '../components/ReactivationModal';
+
+// ── Mock subscription status type ────────────────────────────────────────────
+type SubscriptionStatus = 'active' | 'paused' | 'cancelled';
+
+/**
+ * Maximum days after cancellation during which reactivation is allowed.
+ * Surface the CTA only within this window.
+ */
+const REACTIVATION_WINDOW_DAYS = 30;
 
 export default function SubscriptionDetail() {
     const { id } = useParams();
-    const [isPaused, setIsPaused] = useState(false);
-    const [pauseUntilDate, setPauseUntilDate] = useState<string | null>(null);
-    const [isResuming, setIsResuming] = useState(false);
+
+    // ── Schedule-change preview state ─────────────────────────────────────────
+    const [pendingInterval, setPendingInterval] = useState<BillingInterval | null>(null);
+
+    // ── Reactivation state ────────────────────────────────────────────────────
+    const [isReactivationModalOpen, setIsReactivationModalOpen] = useState(false);
+    const [isReactivating, setIsReactivating] = useState(false);
 
     const handleViewFullUsage = () => {
         console.log('Navigate to full usage page');
         // TODO: Navigate to full usage page or expand section
     };
 
-    const handleResume = async () => {
-        setIsResuming(true);
-        try {
-            // TODO: Call API to resume subscription
-            console.log('Resuming subscription', id);
-            // Simulate API call
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            setIsPaused(false);
-            setPauseUntilDate(null);
-        } catch (error) {
-            console.error('Failed to resume subscription:', error);
-        } finally {
-            setIsResuming(false);
-        }
-    };
-
-    // Mock data - replace with actual API data
-    const isUsageBased = true; // Determine from subscription data
+    // ── Mock data — replace with actual API responses ─────────────────────────
+    const isUsageBased = true;
     const usageData = {
         billingPeriod: 'Mar 1 — Mar 31',
         usage: '32450 API calls',
-        estimatedCharge: '10 USDC'
+        estimatedCharge: '10 USDC',
     };
+
+    // Mock subscription metadata
+    const subscriptionStatus: SubscriptionStatus = 'cancelled';
+    const cancelledAt = new Date();
+    cancelledAt.setDate(cancelledAt.getDate() - 7); // cancelled 7 days ago
+
+    const subscription = {
+        currentInterval: 'weekly' as BillingInterval,
+        nextCharge: '2026-08-05',
+        amount: 50,
+        currency: 'USDC',
+        billingDay: 15, // subscriber's original billing day of month
+    };
+
+    // Plan data for the reactivation modal
+    const reactivationPlan: ReactivationPlan = {
+        name: 'Pro Monthly',
+        interval: 'Monthly',
+        price: '50 USDC',
+        deleted: false,
+    };
+
+    // Only surface the CTA when reactivation is within the support window
+    const daysSinceCancellation = Math.floor(
+        (Date.now() - cancelledAt.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    const isWithinWindow = daysSinceCancellation <= REACTIVATION_WINDOW_DAYS;
+    const showReactivateCTA = subscriptionStatus === 'cancelled' && isWithinWindow;
+
+    // Reactivation handler — swap out the console.log for your API call
+    const handleReactivateConfirm = async (startDate: Date) => {
+        setIsReactivating(true);
+        try {
+            console.log('Reactivating subscription', id, 'with start date', startDate.toISOString());
+            // TODO: await api.subscriptions.reactivate(id, { startDate })
+            await new Promise(resolve => setTimeout(resolve, 1200));
+            setIsReactivationModalOpen(false);
+        } catch (err) {
+            console.error('Reactivation failed:', err);
+        } finally {
+            setIsReactivating(false);
+        }
+    };
+
+    const intervalOptions: { label: string; value: BillingInterval }[] = [
+        { label: 'Weekly', value: 'weekly' },
+        { label: 'Every 2 weeks', value: 'biweekly' },
+        { label: 'Monthly', value: 'monthly' },
+        { label: 'Quarterly', value: 'quarterly' },
+        { label: 'Yearly', value: 'yearly' },
+    ];
 
     return (
         <div style={{ padding: '2rem', background: '#0a0a0a', minHeight: '100vh', color: '#f8fafc' }}>
+
+            {/* ── Page header with optional Reactivate CTA ──────────────────── */}
             <div style={{ marginBottom: '2rem' }}>
-                <Link to="/subscriptions" style={{ color: '#94a3b8', textDecoration: 'none', marginBottom: '1rem', display: 'inline-block' }}>
+                <Link
+                    to="/subscriptions"
+                    style={{ color: '#94a3b8', textDecoration: 'none', marginBottom: '1rem', display: 'inline-block' }}
+                >
                     &larr; Back to Subscriptions
                 </Link>
-                <h1 style={{ margin: '0 0 0.5rem' }}>Subscription {id}</h1>
-                <p style={{ color: '#64748b', margin: 0 }}>View details and recent payments for this subscription.</p>
+
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+                    <div>
+                        <h1 style={{ margin: '0 0 0.5rem' }}>Subscription {id}</h1>
+                        <p style={{ color: '#64748b', margin: 0 }}>
+                            View details and recent payments for this subscription.
+                        </p>
+                    </div>
+
+                    {/* Reactivate CTA — only for cancelled subs within the support window */}
+                    {showReactivateCTA && (
+                        <button
+                            onClick={() => setIsReactivationModalOpen(true)}
+                            style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: '0.5rem',
+                                padding: '0.625rem 1.25rem',
+                                borderRadius: '12px',
+                                border: '1px solid rgba(0,204,255,0.45)',
+                                background: 'rgba(0,204,255,0.1)',
+                                color: '#00ccff',
+                                fontWeight: 700,
+                                fontSize: '0.9rem',
+                                cursor: 'pointer',
+                                transition: 'all 0.15s ease',
+                                flexShrink: 0,
+                            }}
+                            aria-label="Reactivate this subscription"
+                        >
+                            {/* Refresh icon */}
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                            >
+                                <polyline points="23 4 23 10 17 10" />
+                                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                            </svg>
+                            Reactivate
+                        </button>
+                    )}
+                </div>
+
+                {/* Reactivation window notice */}
+                {subscriptionStatus === 'cancelled' && !isWithinWindow && (
+                    <div
+                        style={{
+                            marginTop: '1rem',
+                            padding: '0.75rem 1rem',
+                            borderRadius: '10px',
+                            border: '1px solid rgba(251,191,36,0.25)',
+                            background: 'rgba(251,191,36,0.05)',
+                            fontSize: '0.8125rem',
+                            color: '#94a3b8',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.5rem',
+                        }}
+                        role="status"
+                    >
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="#fbbf24"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden="true"
+                        >
+                            <circle cx="12" cy="12" r="10" />
+                            <line x1="12" y1="8" x2="12" y2="12" />
+                            <line x1="12" y1="16" x2="12.01" y2="16" />
+                        </svg>
+                        Reactivation window has expired. Browse plans to start a new subscription.
+                    </div>
+                )}
             </div>
 
-            {/* Dunning banner - shown when there are failed attempts for this subscription */}
+            {/* ── Dunning banner ────────────────────────────────────────────── */}
             <PaymentFailedBanner
                 subscriptionId={id}
                 failedAttempts={1}
@@ -60,12 +198,11 @@ export default function SubscriptionDetail() {
                     { id: 'r3', when: 'Mar 30 — Final retry', status: 'upcoming' },
                 ]}
                 onFixPayment={() => {
-                    // Ideally route to payment method flow
                     console.log('Open fix payment flow for subscription', id);
                 }}
             />
 
-            {/* Usage This Period Section - Only for usage-based subscriptions */}
+            {/* ── Usage this period ─────────────────────────────────────────── */}
             {isUsageBased && (
                 <div style={{ marginBottom: '2rem' }}>
                     <UsageThisPeriod
@@ -77,9 +214,71 @@ export default function SubscriptionDetail() {
                 </div>
             )}
 
-            <RecentPayments subscriptionId={id} />
+            {/* ── Billing schedule / schedule-change preview ────────────────── */}
+            <div style={{ marginBottom: '2rem' }}>
+                <h2 style={{ fontSize: '1rem', fontWeight: 600, color: '#e2e8f0', marginBottom: '0.75rem' }}>
+                    Billing schedule
+                </h2>
 
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: '0.875rem', color: '#94a3b8' }}>Change to:</span>
+                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                        {intervalOptions
+                            .filter(opt => opt.value !== subscription.currentInterval)
+                            .map(opt => (
+                                <button
+                                    key={opt.value}
+                                    onClick={() =>
+                                        setPendingInterval((prev: BillingInterval | null) => prev === opt.value ? null : opt.value)
+                                    }
+                                    aria-pressed={pendingInterval === opt.value}
+                                    style={{
+                                        padding: '0.375rem 0.875rem',
+                                        borderRadius: '9999px',
+                                        fontSize: '0.8125rem',
+                                        fontWeight: 600,
+                                        cursor: 'pointer',
+                                        border: pendingInterval === opt.value
+                                            ? '1px solid rgba(0,204,255,0.6)'
+                                            : '1px solid #2a2a2a',
+                                        background: pendingInterval === opt.value
+                                            ? 'rgba(0,204,255,0.12)'
+                                            : '#111',
+                                        color: pendingInterval === opt.value ? '#00ccff' : '#94a3b8',
+                                        transition: 'all 0.15s ease',
+                                    }}
+                                >
+                                    {opt.label}
+                                </button>
+                            ))}
+                    </div>
+                </div>
+
+                {pendingInterval && (
+                    <ScheduleChangePreview
+                        currentNextCharge={subscription.nextCharge}
+                        currentInterval={subscription.currentInterval}
+                        newInterval={pendingInterval}
+                        amount={subscription.amount}
+                        currency={subscription.currency}
+                        cycles={3}
+                    />
+                )}
+            </div>
+
+            <RecentPayments subscriptionId={id} />
             <PlanStatusTimeline subscriptionId={id} />
+
+            {/* ── Reactivation modal ────────────────────────────────────────── */}
+            <ReactivationModal
+                isOpen={isReactivationModalOpen}
+                onClose={() => setIsReactivationModalOpen(false)}
+                onConfirm={handleReactivateConfirm}
+                plan={reactivationPlan}
+                windowExpired={!isWithinWindow}
+                billingDay={subscription.billingDay}
+                isLoading={isReactivating}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Implements the subscription reactivation flow for cancelled subscriptions on the `SubscriptionDetail` page. Users who cancelled and changed their mind can now restore their prior plan with a single confirm — no need to recreate from scratch.

## Changes

### New files
- `src/components/ReactivationModal.tsx` — confirm modal with plan summary, start-date picker, microcopy, edge-case handling
- `src/components/ReactivationModal.css` — scoped CSS matching `PauseSubscriptionModal` visual language
- `src/components/ReactivationModal.test.tsx` — 47 unit tests

### Modified files
- `src/pages/SubscriptionDetail.tsx` — Reactivate CTA + modal integration
- `package.json` — fix pre-existing trailing comma

## Design decisions

| Requirement | Implementation |
|---|---|
| Single-confirm reactivation | `ReactivationModal` with plan summary card + confirm/cancel actions |
| Start-date picker | Three pill buttons: "Start today", "Same billing day", "Custom date" |
| "Same billing day" | Hidden when billing day === today; shows next occurrence + day number |
| Custom date | Inline `DatePickerCalendar` with `minDate=today`, `maxDate=today+90` |
| Microcopy | Per-mode notice explaining billing-day rounding and pro-ration |
| Only show when possible | CTA visible only for `status=cancelled` within 30-day `REACTIVATION_WINDOW_DAYS` |
| Expired window | Yellow banner + confirm disabled; CTA replaced by notice in header |
| Deleted plan | Red alert in plan card + confirm disabled |

## Accessibility (WCAG 2.1 AA)

- `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-describedby`
- All SVG icons `aria-hidden="true"` — text carries semantic meaning
- Date option pills use `aria-pressed`; pill group has `role="group"` + `aria-labelledby`
- `<time>` elements carry `dateTime` ISO attributes
- Focus trapped via `useModalFocus`; Escape closes; focus restores to trigger
- RTL-safe: close button repositioned, layout reflowed via `[dir=rtl]` CSS

## Testing

- **47 tests, all passing**
- 0 lint errors in new/modified files
- Covers: render, open/closed, all three start-date modes, aria-pressed, microcopy per mode, confirm disabled states (deleted plan, expired window, loading, custom-no-date), `onConfirm` date accuracy, loading state, state reset on reopen, RTL render, snapshots

## Before / After

**Before:** Cancelled subscribers had to recreate from scratch via Browse Plans.

**After:** A "Reactivate" CTA appears in the header for cancelled subs within the 30-day window:

```
┌──────────────────────────────────────────────────────────────────┐
│ ↻  Reactivate subscription?                                 ✕   │
│                                                                    │
│  Restore your Pro Monthly plan with the same settings.            │
│  Choose when billing should restart.                              │
│                                                                    │
│  ┌─────────────────────────────────────────┐                     │
│  │ Pro Monthly · Monthly           50 USDC │                     │
│  └─────────────────────────────────────────┘                     │
│                                                                    │
│  Start date                                                       │
│  [ Start today ] [ Same billing day · Day 15 ] [ Custom date ]   │
│                                                                    │
│  ℹ Access and billing begin today, Aug 1, 2026.                  │
│                                                                    │
│  [ Keep cancelled ]              [ Reactivate ]                  │
└──────────────────────────────────────────────────────────────────┘
```

Closes #361