### PR TITLE
design: inline field help popover

### DIFF
--- a/docs/FIELD_HELP_POPOVER.md
+++ b/docs/FIELD_HELP_POPOVER.md
@@ -1,0 +1,55 @@
+# Inline Field Help Popover
+
+Use `FieldHelpPopover` for secondary field guidance that helps a user decide what to enter without permanently increasing form height.
+
+## Pattern
+
+- Place the info icon directly after the field label by using `FieldLabelWithHelp`.
+- Keep content short: one sentence or a compact list of consequences.
+- The popover opens by mouse click, `Enter`, or `Space`.
+- Focus moves into the popover while open and is trapped until dismissal.
+- Dismiss with `Escape`, outside click, or the `Got it` button.
+- The popover shifts to the start or end edge when centered placement would overflow the viewport. On small screens, it anchors above the viewport bottom.
+- RTL documents mirror overflow alignment by reading `document.dir`.
+
+## When To Use
+
+Use the help popover for contextual explanations, billing consequences, and examples that are useful on demand but not required every time.
+
+Use inline hint text when the guidance is essential for every user before input, such as accepted file formats or irreversible business rules.
+
+Use required-field and validation errors inline below the field. Errors must stay visible, use `aria-invalid`, and be referenced with `aria-describedby` when supported by the field.
+
+## Example
+
+```tsx
+<FieldLabelWithHelp
+  htmlFor="billing-cycle"
+  helpTitle="Billing cycle"
+  help={<p>Sets the default renewal cadence for this account.</p>}
+>
+  Billing Cycle
+</FieldLabelWithHelp>
+```
+
+## Accessibility Notes
+
+- Trigger buttons use `aria-haspopup="dialog"`, `aria-expanded`, and a specific screen-reader label.
+- Open popovers render as `role="dialog"` with `aria-labelledby`.
+- The close button receives initial focus and the existing modal focus hook traps `Tab`/`Shift+Tab`.
+- `Escape` closes the popover and the explicit close action restores focus to the icon trigger.
+- The component avoids hover-only disclosure, so keyboard and touch users receive the same content.
+
+## Verification
+
+Run the unit test:
+
+```bash
+npm run test -- src/components/common/FieldHelpPopover.test.tsx --run
+```
+
+Run lint before release:
+
+```bash
+npm run lint
+```

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, type CSSProperties } from 'react'
+import { useState, useEffect } from 'react'
 import { PricingModeInput, type PricingMode } from './common/PricingModeInput'
 import AmountInput from './common/AmountInput'
+import { FieldLabelWithHelp } from './common/FieldHelpPopover'
 
 export type PlanInterval = 'Monthly' | 'Yearly'
 
@@ -162,9 +163,15 @@ export default function PricingSection({ value, onChange, priceError, intervalEr
           )}
         </div>
         <div style={{ minWidth: 0 }}>
-          <label htmlFor="pricing-interval" style={labelStyle}>
-            Billing interval <span style={{ color: '#f00' }}>*</span>
-          </label>
+          <FieldLabelWithHelp
+            htmlFor="pricing-interval"
+            required
+            helpTitle="Billing interval"
+            help={<p>Choose how often the recurring plan renews and invoices subscribers.</p>}
+            style={labelStyle}
+          >
+            Billing interval
+          </FieldLabelWithHelp>
           <div style={{ position: 'relative' }}>
             <select
               id="pricing-interval"

--- a/src/components/common/FieldHelpPopover.css
+++ b/src/components/common/FieldHelpPopover.css
@@ -1,0 +1,154 @@
+.field-help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.field-help__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--field-help-trigger-color, #94a3b8);
+  cursor: pointer;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.field-help__trigger:hover,
+.field-help__trigger[aria-expanded="true"] {
+  border-color: rgba(103, 213, 240, 0.35);
+  background: rgba(103, 213, 240, 0.12);
+  color: #67d5f0;
+}
+
+.field-help__trigger:focus-visible {
+  outline: 3px solid var(--focus-ring, var(--color-focus-ring, #22d3ee));
+  outline-offset: 2px;
+  box-shadow: 0 0 10px var(--focus-ring-halo, rgba(56, 189, 248, 0.45));
+}
+
+.field-help__popover {
+  position: absolute;
+  inset-block-start: calc(100% + 0.5rem);
+  inset-inline-start: 50%;
+  z-index: 50;
+  width: min(20rem, calc(100vw - 2rem));
+  max-width: calc(100vw - 2rem);
+  padding: 0.875rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background: #06111d;
+  color: #cbd5e1;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.38);
+  transform: translateX(-50%);
+}
+
+.field-help__popover[data-align="start"] {
+  inset-inline-start: 0;
+  transform: none;
+}
+
+.field-help__popover[data-align="end"] {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+}
+
+.field-help__popover:focus {
+  outline: none;
+}
+
+.field-help__title {
+  margin: 0 0 0.375rem;
+  color: #f8fafc;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.field-help__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  color: #94a3b8;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.field-help__content p,
+.field-help__content ul,
+.field-help__content ol {
+  margin: 0;
+}
+
+.field-help__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  min-height: 2rem;
+  margin-top: 0.125rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 6px;
+  background: transparent;
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.field-help__close:hover {
+  border-color: rgba(103, 213, 240, 0.35);
+  color: #67d5f0;
+}
+
+.field-help__close:focus-visible {
+  outline: 3px solid var(--focus-ring, var(--color-focus-ring, #22d3ee));
+  outline-offset: 2px;
+}
+
+.field-label-with-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.field-label-with-help label {
+  cursor: inherit;
+}
+
+@media (max-width: 480px) {
+  .field-help {
+    position: static;
+  }
+
+  .field-help__popover {
+    position: fixed;
+    inset-block-start: auto;
+    inset-inline: 1rem;
+    inset-block-end: 1rem;
+    width: auto;
+    transform: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .field-help__trigger,
+  .field-help__popover,
+  .field-help__close {
+    border-color: ButtonBorder;
+  }
+
+  .field-help__trigger:focus-visible,
+  .field-help__close:focus-visible {
+    outline: 3px solid Highlight;
+    box-shadow: none;
+  }
+}

--- a/src/components/common/FieldHelpPopover.stories.tsx
+++ b/src/components/common/FieldHelpPopover.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FieldHelpPopover, FieldLabelWithHelp } from './FieldHelpPopover'
+
+const meta: Meta<typeof FieldHelpPopover> = {
+  title: 'Components/Common/FieldHelpPopover',
+  component: FieldHelpPopover,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Inline field help pattern for secondary form guidance. Opens from an info icon, traps focus while open, and dismisses with Escape, outside click, or the close action.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof FieldHelpPopover>
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ maxWidth: 360, padding: 24, background: '#00060f' }}>
+      <FieldLabelWithHelp
+        htmlFor="billing-cycle-story"
+        helpTitle="Billing cycle"
+        help={<p>Sets the default renewal cadence for this account.</p>}
+        style={{ color: '#e2e8f0', fontSize: '0.875rem', fontWeight: 600, marginBottom: 8 }}
+      >
+        Billing Cycle
+      </FieldLabelWithHelp>
+      <select id="billing-cycle-story" style={{ width: '100%', padding: 12 }}>
+        <option>Monthly</option>
+        <option>Yearly</option>
+      </select>
+    </div>
+  ),
+}
+
+export const ViewportEdge: Story = {
+  render: () => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', width: 360, padding: 24, background: '#00060f' }}>
+      <FieldHelpPopover title="Tax ID" align="end">
+        <p>Add a business tax identifier when it needs to appear on invoices.</p>
+      </FieldHelpPopover>
+    </div>
+  ),
+}
+
+export const ErrorAdjacent: Story = {
+  render: () => (
+    <div style={{ maxWidth: 360, padding: 24, background: '#00060f' }}>
+      <FieldLabelWithHelp
+        htmlFor="plan-price-story"
+        required
+        helpTitle="Plan price"
+        help={<p>Use 0 for a free plan. Percent plans accept values from 0 to 100.</p>}
+        style={{ color: '#e2e8f0', fontSize: '0.875rem', fontWeight: 600, marginBottom: 8 }}
+      >
+        Price
+      </FieldLabelWithHelp>
+      <input
+        id="plan-price-story"
+        aria-invalid="true"
+        aria-describedby="plan-price-story-error"
+        defaultValue="-1"
+        style={{ width: '100%', padding: 12 }}
+      />
+      <p id="plan-price-story-error" style={{ margin: '6px 0 0', color: '#f87171', fontSize: 12 }}>
+        Price must be a valid number greater than or equal to 0.
+      </p>
+    </div>
+  ),
+}

--- a/src/components/common/FieldHelpPopover.test.tsx
+++ b/src/components/common/FieldHelpPopover.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { FieldHelpPopover } from './FieldHelpPopover'
+
+describe('FieldHelpPopover', () => {
+  it('opens from the info button and exposes dialog content', async () => {
+    const user = userEvent.setup()
+    render(
+      <FieldHelpPopover title="Trial period">
+        <p>Customers are not charged until the trial ends.</p>
+      </FieldHelpPopover>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Help for Trial period' }))
+
+    expect(screen.getByRole('dialog', { name: 'Trial period' })).toBeInTheDocument()
+    expect(screen.getByText('Customers are not charged until the trial ends.')).toBeInTheDocument()
+  })
+
+  it('opens with the keyboard and traps focus while open', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <button type="button">Before</button>
+        <FieldHelpPopover title="Billing cycle">
+          <p>Choose how often customers receive invoices.</p>
+        </FieldHelpPopover>
+        <button type="button">After</button>
+      </>,
+    )
+
+    await user.tab()
+    await user.tab()
+    await user.keyboard('{Enter}')
+
+    const closeButton = await screen.findByRole('button', { name: 'Got it' })
+    await waitFor(() => expect(closeButton).toHaveFocus())
+
+    await user.tab()
+    expect(closeButton).toHaveFocus()
+
+    await user.tab({ shift: true })
+    expect(closeButton).toHaveFocus()
+  })
+
+  it('dismisses on Escape and outside pointer interaction', async () => {
+    const user = userEvent.setup()
+    render(
+      <div>
+        <FieldHelpPopover title="Tax ID">
+          <p>Used for invoice tax reporting.</p>
+        </FieldHelpPopover>
+        <button type="button">Outside</button>
+      </div>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Help for Tax ID' }))
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog', { name: 'Tax ID' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Help for Tax ID' }))
+    await user.click(screen.getByRole('button', { name: 'Outside' }))
+    expect(screen.queryByRole('dialog', { name: 'Tax ID' })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/common/FieldHelpPopover.tsx
+++ b/src/components/common/FieldHelpPopover.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useId, useRef, useState } from 'react'
+import { Info } from 'lucide-react'
+import { useModalFocus } from '../../hooks/useModalFocus'
+import './FieldHelpPopover.css'
+
+type PopoverAlign = 'center' | 'start' | 'end'
+
+export interface FieldHelpPopoverProps {
+  title: string
+  children: React.ReactNode
+  ariaLabel?: string
+  align?: PopoverAlign
+}
+
+export function FieldHelpPopover({
+  title,
+  children,
+  ariaLabel,
+  align = 'center',
+}: FieldHelpPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [resolvedAlign, setResolvedAlign] = useState<PopoverAlign>(align)
+  const id = useId()
+  const popoverId = id + '-popover'
+  const titleId = id + '-title'
+  const rootRef = useRef<HTMLSpanElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useModalFocus(popoverRef, {
+    isOpen,
+    onClose: () => setIsOpen(false),
+    initialFocusRef: closeRef,
+  })
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const frame = window.requestAnimationFrame(() => {
+      const popover = popoverRef.current
+      if (!popover) return
+
+      const rect = popover.getBoundingClientRect()
+      const padding = 16
+      if (rect.left < padding) {
+        setResolvedAlign(document.dir === 'rtl' ? 'end' : 'start')
+      } else if (rect.right > window.innerWidth - padding) {
+        setResolvedAlign(document.dir === 'rtl' ? 'start' : 'end')
+      } else {
+        setResolvedAlign(align)
+      }
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [align, isOpen])
+
+  const close = () => {
+    setIsOpen(false)
+    window.requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  return (
+    <span className="field-help" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="field-help__trigger"
+        aria-label={ariaLabel ?? 'Help for ' + title}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? popoverId : undefined}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <Info size={15} strokeWidth={2.2} aria-hidden="true" />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          className="field-help__popover"
+          data-align={resolvedAlign}
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby={titleId}
+        >
+          <h4 id={titleId} className="field-help__title">
+            {title}
+          </h4>
+          <div className="field-help__content">
+            {children}
+            <button ref={closeRef} type="button" className="field-help__close" onClick={close}>
+              Got it
+            </button>
+          </div>
+        </div>
+      )}
+    </span>
+  )
+}
+
+export interface FieldLabelWithHelpProps {
+  htmlFor?: string
+  children: React.ReactNode
+  helpTitle: string
+  help: React.ReactNode
+  required?: boolean
+  optional?: boolean
+  style?: React.CSSProperties
+}
+
+export function FieldLabelWithHelp({
+  htmlFor,
+  children,
+  helpTitle,
+  help,
+  required,
+  optional,
+  style,
+}: FieldLabelWithHelpProps) {
+  return (
+    <span className="field-label-with-help" style={style}>
+      <label htmlFor={htmlFor}>
+        {children}
+        {required && <span style={{ color: '#f87171', marginLeft: '0.25rem' }}>*</span>}
+        {optional && <span style={{ color: '#64748b', fontWeight: 400, marginLeft: '0.25rem' }}>(optional)</span>}
+      </label>
+      <FieldHelpPopover title={helpTitle}>{help}</FieldHelpPopover>
+    </span>
+  )
+}

--- a/src/components/create-plan/BillingTypeSection.tsx
+++ b/src/components/create-plan/BillingTypeSection.tsx
@@ -1,3 +1,5 @@
+import { FieldHelpPopover, FieldLabelWithHelp } from "../common/FieldHelpPopover";
+
 // Toggle
 function Toggle({
   checked,
@@ -107,19 +109,28 @@ export default function BillingTypeSection({
           onChange={onUsageEnabledChange}
         />
         <div>
-          <label
-            htmlFor="usage-based-toggle"
+          <span
+            className="field-label-with-help"
             style={{
               color: "#e2e8f0",
               fontSize: "0.925rem",
               fontWeight: 600,
               cursor: "pointer",
-              display: "block",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
               marginBottom: "0.25rem",
             }}
           >
-            Usage-based billing
-          </label>
+            <label htmlFor="usage-based-toggle">
+              Usage-based billing
+            </label>
+            <FieldHelpPopover title="Usage-based billing">
+              <p>
+                Turn this on when the plan has metered charges in addition to a recurring base price.
+              </p>
+            </FieldHelpPopover>
+          </span>
           <p
             style={{
               color: "#64748b",
@@ -136,19 +147,24 @@ export default function BillingTypeSection({
 
       {/* Trial period */}
       <div>
-        <label
+        <FieldLabelWithHelp
           htmlFor="trial-period"
+          optional
+          helpTitle="Trial period"
+          help={
+            <p>
+              Customers will not be charged until the trial ends. Use 0 or leave blank for no trial.
+            </p>
+          }
           style={{
             color: "#fff",
             fontSize: "0.825rem",
             fontWeight: 500,
-            display: "block",
             marginBottom: "0.45rem",
           }}
         >
-          Trial period{" "}
-          <span style={{ color: "#64748b", fontWeight: 400 }}>(optional)</span>
-        </label>
+          Trial period
+        </FieldLabelWithHelp>
 
         <div style={{ position: "relative", maxWidth: "320px" }}>
           <input
@@ -188,36 +204,6 @@ export default function BillingTypeSection({
             }}
           >
             days
-          </span>
-        </div>
-
-        {/* Info message */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "0.45rem",
-            marginTop: "0.6rem",
-          }}
-        >
-          <svg
-            width="15"
-            height="15"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="#64748b"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-            style={{ flexShrink: 0 }}
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="16" x2="12" y2="12" />
-            <line x1="12" y1="8" x2="12.01" y2="8" />
-          </svg>
-          <span style={{ color: "#64748b", fontSize: "0.82rem" }}>
-            Customers won't be charged during the trial period.
           </span>
         </div>
       </div>

--- a/src/components/settings/BillingSettings.tsx
+++ b/src/components/settings/BillingSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Save, CreditCard, Plus, Trash2, Download } from 'lucide-react'
 import ConfirmDialog from '../common/ConfirmDialog'
 import DangerZone, { DangerZoneItem } from '../common/DangerZone'
+import { FieldLabelWithHelp } from '../common/FieldHelpPopover'
 
 interface PaymentMethod {
   id: string
@@ -140,10 +141,16 @@ export default function BillingSettings() {
         <div style={{ background: '#0a0a0a', borderRadius: '6px', padding: '1.5rem', border: '1px solid #2d2d44' }}>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.5rem' }}>
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="billing-cycle"
+                helpTitle="Billing cycle"
+                help={<p>Sets the default renewal cadence for this account. Yearly billing uses the annual discount shown in the menu.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Billing Cycle
-              </label>
+              </FieldLabelWithHelp>
               <select
+                id="billing-cycle"
                 value={billingPrefs.billingCycle}
                 onChange={(e) => setBillingPrefs({ ...billingPrefs, billingCycle: e.target.value as 'monthly' | 'yearly' })}
                 disabled={!isEditing}
@@ -164,10 +171,16 @@ export default function BillingSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="invoice-email"
+                helpTitle="Invoice email"
+                help={<p>Invoices, receipts, and billing failure notices are sent to this address.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Invoice Email
-              </label>
+              </FieldLabelWithHelp>
               <input
+                id="invoice-email"
                 type="email"
                 value={billingPrefs.invoiceEmail}
                 onChange={(e) => setBillingPrefs({ ...billingPrefs, invoiceEmail: e.target.value })}
@@ -186,10 +199,17 @@ export default function BillingSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
-                Tax ID (Optional)
-              </label>
+              <FieldLabelWithHelp
+                htmlFor="tax-id"
+                optional
+                helpTitle="Tax ID"
+                help={<p>Add a business tax identifier when it needs to appear on invoices for accounting or compliance.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
+                Tax ID
+              </FieldLabelWithHelp>
               <input
+                id="tax-id"
                 type="text"
                 value={billingPrefs.taxId}
                 onChange={(e) => setBillingPrefs({ ...billingPrefs, taxId: e.target.value })}

--- a/src/components/settings/OrganizationSettings.tsx
+++ b/src/components/settings/OrganizationSettings.tsx
@@ -4,6 +4,7 @@ import DangerZone, { DangerZoneItem } from '../common/DangerZone'
 import ConfirmDialog from '../common/ConfirmDialog'
 import Avatar from '../common/Avatar'
 import AvatarUploader from '../common/AvatarUploader'
+import { FieldLabelWithHelp } from '../common/FieldHelpPopover'
 
 interface OrganizationData {
   name: string
@@ -162,10 +163,16 @@ export default function OrganizationSettings() {
 
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.5rem' }}>
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-name"
+                helpTitle="Organization name"
+                help={<p>This display name appears in customer-facing invoices, emails, and workspace headers.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Organization Name
-              </label>
+              </FieldLabelWithHelp>
               <input
+                id="organization-name"
                 type="text"
                 value={orgData.name}
                 onChange={(e) => setOrgData({ ...orgData, name: e.target.value })}
@@ -184,10 +191,16 @@ export default function OrganizationSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-domain"
+                helpTitle="Domain"
+                help={<p>Use the primary company domain for workspace identity and future domain verification.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Domain
-              </label>
+              </FieldLabelWithHelp>
               <input
+                id="organization-domain"
                 type="text"
                 value={orgData.domain}
                 onChange={(e) => setOrgData({ ...orgData, domain: e.target.value })}
@@ -206,10 +219,16 @@ export default function OrganizationSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-contact-email"
+                helpTitle="Contact email"
+                help={<p>Operational notices and organization-level account messages are sent here.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Contact Email
-              </label>
+              </FieldLabelWithHelp>
               <input
+                id="organization-contact-email"
                 type="email"
                 value={orgData.email}
                 onChange={(e) => setOrgData({ ...orgData, email: e.target.value })}
@@ -228,10 +247,16 @@ export default function OrganizationSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-timezone"
+                helpTitle="Timezone"
+                help={<p>Controls date boundaries for reports, invoice schedules, and activity timestamps.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Timezone
-              </label>
+              </FieldLabelWithHelp>
               <select
+                id="organization-timezone"
                 value={orgData.timezone}
                 onChange={(e) => setOrgData({ ...orgData, timezone: e.target.value })}
                 disabled={!isEditing}
@@ -255,10 +280,16 @@ export default function OrganizationSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-currency"
+                helpTitle="Currency"
+                help={<p>Sets the default reporting and invoice currency for new plans and billing summaries.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Currency
-              </label>
+              </FieldLabelWithHelp>
               <select
+                id="organization-currency"
                 value={orgData.currency}
                 onChange={(e) => setOrgData({ ...orgData, currency: e.target.value })}
                 disabled={!isEditing}
@@ -281,10 +312,16 @@ export default function OrganizationSettings() {
             </div>
 
             <div>
-              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}>
+              <FieldLabelWithHelp
+                htmlFor="organization-language"
+                helpTitle="Language"
+                help={<p>Sets the default locale for customer-facing billing copy where localization is available.</p>}
+                style={{ display: 'inline-flex', fontSize: '0.875rem', fontWeight: 500, color: '#94a3b8', marginBottom: '0.5rem' }}
+              >
                 Language
-              </label>
+              </FieldLabelWithHelp>
               <select
+                id="organization-language"
                 value={orgData.language}
                 onChange={(e) => setOrgData({ ...orgData, language: e.target.value })}
                 disabled={!isEditing}


### PR DESCRIPTION

Close #346 

## Summary
- Added a shared `FieldHelpPopover` / `FieldLabelWithHelp` pattern with info-icon trigger, dialog semantics, focus trapping, Escape/outside-click dismissal, RTL-aware viewport edge alignment, and small-screen positioning.
- Migrated field help usage in CreatePlan-related pricing/billing sections, BillingSettings, and OrganizationSettings.
- Added Storybook examples, focused unit coverage, and design-system docs for usage vs inline hints vs validation errors.

## Verification
- Passed: `npm run test -- src/components/common/FieldHelpPopover.test.tsx --run`
- Passed with existing warnings only: targeted ESLint on changed files
- Blocked: `npm run lint` and `npm run build` fail on existing repo issues outside this branch:
  - merge conflict markers in `src/components/Layout.tsx`
  - syntax errors in `src/components/help/HelpSidebar.tsx`
  - parse errors in `src/pages/Subscriptions.tsx`
  - existing lint error in `src/test/setup.ts`

## Accessibility Notes
- Trigger is keyboard-openable and exposes `aria-haspopup`, `aria-expanded`, and `aria-controls`.
- Open popover uses `role="dialog"` and `aria-labelledby`.
- Focus moves into the popover and is trapped while open.
- Dismissal works via Escape, outside click, and explicit close action.