### PR TITLE
design: UsageBilling anomaly alerts panel  - Add UsageAnomalyPanel co…

### DIFF
--- a/docs/USAGE_ANOMALY_PANEL.md
+++ b/docs/USAGE_ANOMALY_PANEL.md
@@ -1,0 +1,150 @@
+# Usage Anomaly Alerts Panel
+
+Design spec and implementation notes for the anomaly-alerts panel on the
+Usage & Billing page (Issue: "Sudden usage spikes surprise subscribers").
+
+Component: `src/components/UsageAnomalyPanel.tsx` (+ `UsageAnomalyPanel.css`)
+Used on: `src/pages/UsageBilling.tsx`
+
+## Problem
+
+Sudden usage spikes currently only show up as a surprise on the invoice.
+This panel surfaces day-over-day and week-over-week usage anomalies inline
+on the Usage & Billing page, with a plain-language explanation and a way to
+quiet alerts a subscriber doesn't want to see again.
+
+## Anatomy
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│ Anomaly alerts                                    [Reset all mutes]│
+│ We flag usage changes greater than 50% day-over-day or 100%        │
+│ week-over-week compared to your trailing 7-day average.            │
+│                                                                     │
+│  ● API calls   Day-over-day   [+340%]                    [Mute]   │
+│    Usage jumped well beyond your typical daily pattern...          │
+│    8,820 calls vs 2,005 calls previously                           │
+│                                                                     │
+│  ● Storage     Week-over-week [+128%]                    [Mute]   │
+│    Storage usage more than doubled compared to last week...        │
+│    41.2 GB vs 18.1 GB previously                                    │
+│                                                                     │
+│ ─────────────────────────────────────────────────────────────────  │
+│ Muted alert types (1)                                               │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+- **Severity dot** — critical (red), warning (amber), info (cyan). Severity
+  is never conveyed by color alone: a visually-hidden `"{Severity} alert:"`
+  prefix is read by screen readers before the metric name (WCAG 1.4.1).
+- **Delta chip** — signed percentage with a direction arrow. For usage
+  billing, an *increase* is the concerning direction (more usage → a bigger
+  invoice), so up-deltas use the danger color and down-deltas use the
+  success color — the inverse of a typical revenue metric. The chip's
+  `aria-label` spells out the direction and magnitude in words (e.g. "Up 340
+  percent") rather than relying on the "+"/"−" glyph and arrow icon, which
+  can be lost or misread by assistive tech.
+- **Reason line** — one sentence of plain-language context for why this was
+  flagged (not just the raw numbers).
+- **Values line** — the raw current-vs-previous numbers for anyone who wants
+  the underlying data.
+- **Mute control** — per anomaly *type* (e.g. "API calls spikes"), not per
+  individual alert instance. Muting hides all current and future rows of
+  that type. A collapsible "Muted alert types (N)" section lists muted
+  types with individual "Unmute" actions, plus a single "Reset all mutes"
+  control in the header once anything is muted.
+
+## Threshold microcopy
+
+The subtitle under the panel title states the detection thresholds in
+plain language so subscribers understand *why* something was flagged:
+
+> We flag usage changes greater than 50% day-over-day or 100% week-over-week
+> compared to your trailing 7-day average.
+
+This is static copy today; if per-metric thresholds become configurable,
+the copy should be generated from the same config the anomaly-detection
+service uses, so it never drifts out of sync with actual behavior.
+
+## Mute persistence
+
+Mute state is scoped to a `typeId` (the kind of anomaly, e.g.
+`api_calls_spike`) and persisted in `localStorage` under
+`stellabill.usageBilling.mutedAnomalyTypes.{userId}`, where `userId` is
+passed in by the host page (`UsageBilling.tsx` passes the subscription
+`id` from the route today; swap in the authenticated user id once auth
+context is available). This namespacing means:
+
+- Muting is per-user, not global to the browser.
+- A "Reset all mutes" control clears the stored set for that user in one
+  action, and reloading the page keeps the reset applied (the exact
+  behavior a subscriber expects from "reset").
+- Storage reads/writes are wrapped in `try`/`catch` — private browsing mode
+  or a full storage quota degrades to "mute lasts for this session only"
+  rather than throwing.
+
+## Accessibility (WCAG 2.1 AA)
+
+- The panel is a labeled landmark: `<section aria-label="Usage anomaly
+  alerts">`.
+- A visually-hidden `role="status" aria-live="polite"` region announces
+  mute/unmute/reset actions ("Muted future API calls alerts.", "Unmuted
+  Storage alerts.", "All muted anomaly types have been reset.") so screen
+  reader users get feedback without focus being moved.
+- Empty and fully-muted states use `role="status"` so their message is
+  announced when they appear.
+- Severity is never color-only (see above).
+- Every mute button has an explicit `aria-label` ("Mute alerts for API
+  calls") rather than relying on the row's visual context.
+- The muted-types list is behind a `button[aria-expanded]` disclosure, not
+  a native `<details>`, to match the rest of the app's toggle pattern
+  (e.g. `ErrorState`'s "Technical Details" toggle).
+- All interactive elements are plain `<button>`s — full keyboard operability
+  (Tab/Shift+Tab/Enter/Space) comes for free, no custom key handling needed.
+- Layout uses `flex` + `gap` (no absolute left/right offsets), so the panel
+  holds up under `dir="rtl"` without additional CSS.
+
+## Responsive behavior
+
+- Rows wrap (`flex-wrap: wrap`) so the metric name, period badge, and delta
+  chip re-flow on narrow viewports instead of clipping.
+- Below 640px, each row switches to a stacked column layout and the mute
+  button left-aligns under the row content instead of sitting flush right.
+- The panel's outer padding shrinks on small screens to match the existing
+  `main-card` treatment on the Usage & Billing page.
+
+## Edge cases handled
+
+| Case | Behavior |
+|---|---|
+| No anomalies for the period | "No usage anomalies detected for this period." (`role="status"`) |
+| Every anomaly type muted | "All anomaly types are currently muted." with an inline reset action |
+| Mixed muted/active types | Active rows render normally; muted types collapse into the "Muted alert types (N)" disclosure |
+| Malformed/corrupt localStorage value | Treated as "nothing muted"; never throws |
+| RTL document direction | Delta values and labels render unchanged; flex/gap layout re-flows correctly |
+| Screen reader users | Mute/unmute/reset actions are announced via a live region; severity and delta direction are available as text, not just color/iconography |
+
+## Testing
+
+`src/components/UsageAnomalyPanel.test.tsx` covers: rendering of anomaly
+rows (metric, period, delta, reason), the accessible delta label, the
+severity text-alternative, muting/unmuting a type, the "all muted" and
+"no anomalies" empty states, the header reset control, per-user mute
+persistence (including isolation between two different `userId`s),
+recovery from malformed `localStorage` data, and rendering under
+`dir="rtl"`.
+
+Run:
+
+```bash
+npm test src/components/UsageAnomalyPanel.test.tsx
+npm run test:coverage
+```
+
+## Files changed
+
+- `src/components/UsageAnomalyPanel.tsx` — new
+- `src/components/UsageAnomalyPanel.css` — new
+- `src/components/UsageAnomalyPanel.test.tsx` — new
+- `src/pages/UsageBilling.tsx` — renders the panel with mock anomaly data
+- `docs/USAGE_ANOMALY_PANEL.md` — this document

--- a/src/components/UsageAnomalyPanel.css
+++ b/src/components/UsageAnomalyPanel.css
@@ -1,0 +1,300 @@
+/* Usage anomaly alerts panel — follows the dark card aesthetic already used on
+   the Usage & Billing page (see src/pages/UsageBilling.css) so the panel reads
+   as part of the same surface rather than a bolted-on widget. */
+
+.anomaly-panel {
+    box-sizing: border-box;
+    width: 100%;
+    background: #000000;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 24px;
+    padding: 33px;
+    margin-bottom: 32px;
+}
+
+.anomaly-panel-header {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.anomaly-panel-header h2 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 28px;
+    letter-spacing: -0.449219px;
+    color: #FFFFFF;
+    margin: 0 0 8px;
+}
+
+.anomaly-panel-subtitle {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 20px;
+    color: #90A1B9;
+    margin: 0;
+    max-width: 56ch;
+}
+
+.anomaly-reset-button,
+.anomaly-muted-toggle,
+.anomaly-unmute-button,
+.anomaly-mute-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 18px;
+    border-radius: 10px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.anomaly-reset-button {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #E2E8F0;
+    padding: 8px 14px;
+    flex-shrink: 0;
+}
+
+.anomaly-reset-button:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.anomaly-empty {
+    font-size: 14px;
+    color: #90A1B9;
+    margin: 0;
+}
+
+.anomaly-inline-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #00D3F3;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.anomaly-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.anomaly-row {
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 16px 18px;
+}
+
+.anomaly-row--critical {
+    border-color: rgba(239, 68, 68, 0.35);
+}
+
+.anomaly-row--warning {
+    border-color: rgba(245, 158, 11, 0.3);
+}
+
+.anomaly-row-main {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    min-width: 0;
+    flex: 1 1 260px;
+}
+
+.anomaly-severity-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-top: 6px;
+    flex-shrink: 0;
+}
+
+.anomaly-severity-dot--critical {
+    background: #ef4444;
+}
+
+.anomaly-severity-dot--warning {
+    background: #f59e0b;
+}
+
+.anomaly-severity-dot--info {
+    background: #00D3F2;
+}
+
+.anomaly-row-content {
+    min-width: 0;
+}
+
+.anomaly-row-heading {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.anomaly-metric-label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #FFFFFF;
+}
+
+.anomaly-period-badge {
+    font-size: 12px;
+    font-weight: 500;
+    color: #90A1B9;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 9999px;
+    padding: 2px 10px;
+}
+
+.anomaly-delta-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.anomaly-delta-chip--up {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+}
+
+.anomaly-delta-chip--down {
+    background: rgba(34, 197, 94, 0.15);
+    color: #4ade80;
+}
+
+.anomaly-delta-chip--unchanged {
+    background: rgba(255, 255, 255, 0.08);
+    color: #90A1B9;
+}
+
+.anomaly-reason {
+    font-size: 13px;
+    color: #CAD5E2;
+    margin: 0 0 4px;
+    line-height: 1.5;
+}
+
+.anomaly-values {
+    font-size: 12px;
+    color: #64748B;
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+}
+
+.anomaly-mute-button {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #90A1B9;
+    padding: 8px 14px;
+    flex-shrink: 0;
+}
+
+.anomaly-mute-button:hover {
+    color: #FFFFFF;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.anomaly-muted-section {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.anomaly-muted-toggle {
+    background: none;
+    border: none;
+    color: #90A1B9;
+    padding: 0;
+}
+
+.anomaly-muted-toggle:hover {
+    color: #FFFFFF;
+}
+
+.anomaly-muted-list {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.anomaly-muted-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 13px;
+    color: #90A1B9;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 10px;
+    padding: 8px 12px;
+}
+
+.anomaly-unmute-button {
+    background: rgba(0, 184, 219, 0.1);
+    border: 1px solid rgba(0, 184, 219, 0.25);
+    color: #53EAFD;
+    padding: 6px 12px;
+}
+
+.anomaly-unmute-button:hover {
+    background: rgba(0, 184, 219, 0.18);
+}
+
+@media (max-width: 640px) {
+    .anomaly-panel {
+        padding: 20px;
+    }
+
+    .anomaly-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .anomaly-mute-button {
+        align-self: flex-start;
+    }
+}

--- a/src/components/UsageAnomalyPanel.test.tsx
+++ b/src/components/UsageAnomalyPanel.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+import UsageAnomalyPanel from './UsageAnomalyPanel';
+import type { UsageAnomaly } from './UsageAnomalyPanel';
+
+const spikeAnomaly: UsageAnomaly = {
+  id: 'a1',
+  typeId: 'api_calls_spike',
+  metricLabel: 'API calls',
+  period: 'day',
+  deltaPercent: 340,
+  currentValue: 8820,
+  previousValue: 2005,
+  unit: 'calls',
+  severity: 'critical',
+  reason: 'Usage jumped well beyond your typical daily pattern.',
+  detectedAt: '2026-03-30T09:00:00Z',
+};
+
+const dropAnomaly: UsageAnomaly = {
+  id: 'a2',
+  typeId: 'storage_growth',
+  metricLabel: 'Storage',
+  period: 'week',
+  deltaPercent: -62,
+  currentValue: 4.2,
+  previousValue: 11.1,
+  unit: 'GB',
+  severity: 'info',
+  reason: 'Storage usage dropped sharply compared to last week.',
+  detectedAt: '2026-03-29T09:00:00Z',
+};
+
+function renderPanel(anomalies: UsageAnomaly[], userId?: string) {
+  return render(<UsageAnomalyPanel anomalies={anomalies} userId={userId} />);
+}
+
+describe('UsageAnomalyPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the panel heading and threshold microcopy', () => {
+    renderPanel([spikeAnomaly]);
+    expect(screen.getByRole('heading', { name: /anomaly alerts/i })).toBeInTheDocument();
+    expect(screen.getByText(/greater than 50% day-over-day/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no anomalies', () => {
+    renderPanel([]);
+    expect(screen.getByText(/no usage anomalies detected/i)).toBeInTheDocument();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('renders each anomaly with metric, period, delta and reason', () => {
+    renderPanel([spikeAnomaly, dropAnomaly]);
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(2);
+
+    const [row1, row2] = rows;
+    expect(within(row1).getByText('API calls')).toBeInTheDocument();
+    expect(within(row1).getByText('Day-over-day')).toBeInTheDocument();
+    expect(within(row1).getByText('+340%')).toBeInTheDocument();
+    expect(within(row1).getByText(spikeAnomaly.reason)).toBeInTheDocument();
+
+    expect(within(row2).getByText('Storage')).toBeInTheDocument();
+    expect(within(row2).getByText('Week-over-week')).toBeInTheDocument();
+    expect(within(row2).getByText('-62%')).toBeInTheDocument();
+  });
+
+  it('gives the delta chip an accessible label describing direction, not just the symbol', () => {
+    renderPanel([spikeAnomaly, dropAnomaly]);
+    expect(screen.getByLabelText('Up 340 percent')).toBeInTheDocument();
+    expect(screen.getByLabelText('Down 62 percent')).toBeInTheDocument();
+  });
+
+  it('conveys severity via text for screen readers, not color alone', () => {
+    renderPanel([spikeAnomaly]);
+    expect(screen.getByText(/critical alert:/i)).toBeInTheDocument();
+  });
+
+  it('mutes an anomaly type, hides its rows, and announces the change', async () => {
+    const user = userEvent.setup();
+    renderPanel([spikeAnomaly, dropAnomaly]);
+
+    await user.click(screen.getByRole('button', { name: /mute alerts for api calls/i }));
+
+    expect(screen.queryByText('API calls')).not.toBeInTheDocument();
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/muted future api calls alerts/i);
+
+    // Muted type is listed and can be unmuted individually.
+    await user.click(screen.getByRole('button', { name: /muted alert types \(1\)/i }));
+    const mutedItem = screen.getByText('API calls').closest('li');
+    expect(mutedItem).not.toBeNull();
+    await user.click(within(mutedItem as HTMLElement).getByRole('button', { name: /unmute/i }));
+
+    expect(screen.getAllByText('API calls')).toHaveLength(1); // back in the active list
+  });
+
+  it('shows an "all muted" message with a reset affordance when every anomaly is muted', async () => {
+    const user = userEvent.setup();
+    renderPanel([spikeAnomaly]);
+
+    await user.click(screen.getByRole('button', { name: /mute alerts for api calls/i }));
+
+    expect(screen.getByText(/all anomaly types are currently muted/i)).toBeInTheDocument();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /reset mutes/i }));
+    expect(screen.getByText('API calls')).toBeInTheDocument();
+  });
+
+  it('resets all mutes via the header reset control', async () => {
+    const user = userEvent.setup();
+    renderPanel([spikeAnomaly, dropAnomaly]);
+
+    await user.click(screen.getByRole('button', { name: /mute alerts for api calls/i }));
+    await user.click(screen.getByRole('button', { name: /mute alerts for storage/i }));
+    expect(screen.getByRole('button', { name: /reset all mutes/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /reset all mutes/i }));
+
+    expect(screen.getByText('API calls')).toBeInTheDocument();
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reset all mutes/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render the reset control or muted section when nothing is muted', () => {
+    renderPanel([spikeAnomaly]);
+    expect(screen.queryByRole('button', { name: /reset all mutes/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/muted alert types/i)).not.toBeInTheDocument();
+  });
+
+  it('persists mute state across remounts for the same user', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderPanel([spikeAnomaly], 'user-1');
+    await user.click(screen.getByRole('button', { name: /mute alerts for api calls/i }));
+    unmount();
+
+    renderPanel([spikeAnomaly], 'user-1');
+    expect(screen.getByText(/all anomaly types are currently muted/i)).toBeInTheDocument();
+  });
+
+  it('scopes mute persistence per user id', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderPanel([spikeAnomaly], 'user-1');
+    await user.click(screen.getByRole('button', { name: /mute alerts for api calls/i }));
+    unmount();
+
+    renderPanel([spikeAnomaly], 'user-2');
+    expect(screen.getByText('API calls')).toBeInTheDocument();
+  });
+
+  it('recovers gracefully when localStorage contains malformed data', () => {
+    window.localStorage.setItem('stellabill.usageBilling.mutedAnomalyTypes.default', 'not-json');
+    expect(() => renderPanel([spikeAnomaly])).not.toThrow();
+    expect(screen.getByText('API calls')).toBeInTheDocument();
+  });
+
+  it('renders correctly under an RTL document direction', () => {
+    const { container } = render(
+      <div dir="rtl">
+        <UsageAnomalyPanel anomalies={[spikeAnomaly, dropAnomaly]} />
+      </div>,
+    );
+
+    expect(container.querySelector('[dir="rtl"]')).toBeInTheDocument();
+    // Delta values must stay intact (not mirrored/reformatted) regardless of direction.
+    expect(screen.getByText('+340%')).toBeInTheDocument();
+    expect(screen.getByText('-62%')).toBeInTheDocument();
+    expect(screen.getByLabelText('Up 340 percent')).toBeInTheDocument();
+  });
+});

--- a/src/components/UsageAnomalyPanel.tsx
+++ b/src/components/UsageAnomalyPanel.tsx
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowUpRight, ArrowDownRight, Bell, BellOff, RotateCcw } from 'lucide-react';
+import './UsageAnomalyPanel.css';
+
+export type AnomalySeverity = 'critical' | 'warning' | 'info';
+export type AnomalyPeriod = 'day' | 'week';
+
+export interface UsageAnomaly {
+  /** Stable id for this specific detection instance. */
+  id: string;
+  /** Stable id for the kind of anomaly (e.g. "api_calls_spike"). Mute is scoped to this. */
+  typeId: string;
+  /** Human readable metric name, e.g. "API calls". */
+  metricLabel: string;
+  period: AnomalyPeriod;
+  /** Signed percentage change vs the comparison window (e.g. 340, -62). */
+  deltaPercent: number;
+  currentValue: number;
+  previousValue: number;
+  unit: string;
+  severity: AnomalySeverity;
+  /** Short plain-language explanation of why this was flagged. */
+  reason: string;
+  /** ISO 8601 timestamp. */
+  detectedAt: string;
+}
+
+interface UsageAnomalyPanelProps {
+  anomalies: UsageAnomaly[];
+  /** Namespaces mute persistence per user. Defaults to a shared key. */
+  userId?: string;
+}
+
+const STORAGE_PREFIX = 'stellabill.usageBilling.mutedAnomalyTypes';
+
+function getStorageKey(userId: string) {
+  return `${STORAGE_PREFIX}.${userId}`;
+}
+
+function loadMutedTypes(userId: string): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(getStorageKey(userId));
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((value): value is string => typeof value === 'string'));
+    }
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function saveMutedTypes(userId: string, muted: Set<string>) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(getStorageKey(userId), JSON.stringify(Array.from(muted)));
+  } catch {
+    // Ignore storage errors (private browsing, quota exceeded, etc.) — mute state
+    // simply won't persist across reloads in that case.
+  }
+}
+
+const PERIOD_LABEL: Record<AnomalyPeriod, string> = {
+  day: 'Day-over-day',
+  week: 'Week-over-week',
+};
+
+const SEVERITY_LABEL: Record<AnomalySeverity, string> = {
+  critical: 'Critical',
+  warning: 'Warning',
+  info: 'Info',
+};
+
+function formatDelta(deltaPercent: number): string {
+  const rounded = Math.round(deltaPercent);
+  const sign = rounded > 0 ? '+' : '';
+  return `${sign}${rounded}%`;
+}
+
+function deltaDirection(deltaPercent: number): 'up' | 'down' | 'unchanged' {
+  if (deltaPercent > 0) return 'up';
+  if (deltaPercent < 0) return 'down';
+  return 'unchanged';
+}
+
+export default function UsageAnomalyPanel({ anomalies, userId = 'default' }: UsageAnomalyPanelProps) {
+  const [mutedTypes, setMutedTypes] = useState<Set<string>>(() => loadMutedTypes(userId));
+  const [showMuted, setShowMuted] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+
+  // Re-sync if the panel is reused for a different user within the same session.
+  useEffect(() => {
+    setMutedTypes(loadMutedTypes(userId));
+  }, [userId]);
+
+  const activeAnomalies = useMemo(
+    () => anomalies.filter((anomaly) => !mutedTypes.has(anomaly.typeId)),
+    [anomalies, mutedTypes],
+  );
+
+  const mutedTypeSummary = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const anomaly of anomalies) {
+      if (mutedTypes.has(anomaly.typeId) && !seen.has(anomaly.typeId)) {
+        seen.set(anomaly.typeId, anomaly.metricLabel);
+      }
+    }
+    return Array.from(seen.entries()).map(([typeId, label]) => ({ typeId, label }));
+  }, [anomalies, mutedTypes]);
+
+  const muteType = useCallback(
+    (typeId: string, label: string) => {
+      setMutedTypes((prev) => {
+        const next = new Set(prev);
+        next.add(typeId);
+        saveMutedTypes(userId, next);
+        return next;
+      });
+      setAnnouncement(`Muted future ${label} alerts.`);
+    },
+    [userId],
+  );
+
+  const unmuteType = useCallback(
+    (typeId: string, label: string) => {
+      setMutedTypes((prev) => {
+        const next = new Set(prev);
+        next.delete(typeId);
+        saveMutedTypes(userId, next);
+        return next;
+      });
+      setAnnouncement(`Unmuted ${label} alerts.`);
+    },
+    [userId],
+  );
+
+  const resetMutes = useCallback(() => {
+    setMutedTypes(() => {
+      const next = new Set<string>();
+      saveMutedTypes(userId, next);
+      return next;
+    });
+    setAnnouncement('All muted anomaly types have been reset.');
+  }, [userId]);
+
+  const hasAnomalies = anomalies.length > 0;
+  const hasActive = activeAnomalies.length > 0;
+  const hasMuted = mutedTypeSummary.length > 0;
+
+  return (
+    <section className="anomaly-panel" aria-label="Usage anomaly alerts">
+      <div className="anomaly-panel-header">
+        <div>
+          <h2>Anomaly alerts</h2>
+          <p className="anomaly-panel-subtitle">
+            We flag usage changes greater than 50% day-over-day or 100% week-over-week compared to
+            your trailing 7-day average.
+          </p>
+        </div>
+        {hasMuted && (
+          <button type="button" className="anomaly-reset-button" onClick={resetMutes}>
+            <RotateCcw size={14} aria-hidden="true" />
+            Reset all mutes
+          </button>
+        )}
+      </div>
+
+      <div className="visually-hidden" role="status" aria-live="polite">
+        {announcement}
+      </div>
+
+      {!hasAnomalies && (
+        <p className="anomaly-empty" role="status">
+          No usage anomalies detected for this period.
+        </p>
+      )}
+
+      {hasAnomalies && !hasActive && (
+        <p className="anomaly-empty" role="status">
+          All anomaly types are currently muted.{' '}
+          <button type="button" className="anomaly-inline-link" onClick={resetMutes}>
+            Reset mutes
+          </button>
+        </p>
+      )}
+
+      {hasActive && (
+        <ul className="anomaly-list">
+          {activeAnomalies.map((anomaly) => (
+            <AnomalyRow
+              key={anomaly.id}
+              anomaly={anomaly}
+              onMute={() => muteType(anomaly.typeId, anomaly.metricLabel)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {hasMuted && (
+        <div className="anomaly-muted-section">
+          <button
+            type="button"
+            className="anomaly-muted-toggle"
+            aria-expanded={showMuted}
+            onClick={() => setShowMuted((value) => !value)}
+          >
+            Muted alert types ({mutedTypeSummary.length})
+          </button>
+          {showMuted && (
+            <ul className="anomaly-muted-list">
+              {mutedTypeSummary.map(({ typeId, label }) => (
+                <li key={typeId} className="anomaly-muted-item">
+                  <span>{label}</span>
+                  <button
+                    type="button"
+                    className="anomaly-unmute-button"
+                    onClick={() => unmuteType(typeId, label)}
+                  >
+                    <Bell size={14} aria-hidden="true" />
+                    Unmute
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AnomalyRow({ anomaly, onMute }: { anomaly: UsageAnomaly; onMute: () => void }) {
+  const direction = deltaDirection(anomaly.deltaPercent);
+  const DeltaIcon = direction === 'up' ? ArrowUpRight : direction === 'down' ? ArrowDownRight : null;
+  const deltaText = formatDelta(anomaly.deltaPercent);
+  const deltaAriaLabel =
+    direction === 'unchanged'
+      ? 'No change'
+      : `${direction === 'up' ? 'Up' : 'Down'} ${Math.abs(Math.round(anomaly.deltaPercent))} percent`;
+
+  return (
+    <li className={`anomaly-row anomaly-row--${anomaly.severity}`}>
+      <div className="anomaly-row-main">
+        <span
+          className={`anomaly-severity-dot anomaly-severity-dot--${anomaly.severity}`}
+          aria-hidden="true"
+        />
+        <div className="anomaly-row-content">
+          <div className="anomaly-row-heading">
+            <span className="visually-hidden">{SEVERITY_LABEL[anomaly.severity]} alert: </span>
+            <span className="anomaly-metric-label">{anomaly.metricLabel}</span>
+            <span className="anomaly-period-badge">{PERIOD_LABEL[anomaly.period]}</span>
+            <span
+              className={`anomaly-delta-chip anomaly-delta-chip--${direction}`}
+              aria-label={deltaAriaLabel}
+            >
+              {DeltaIcon && <DeltaIcon size={12} aria-hidden="true" />}
+              {deltaText}
+            </span>
+          </div>
+          <p className="anomaly-reason">{anomaly.reason}</p>
+          <p className="anomaly-values">
+            {anomaly.currentValue.toLocaleString()} {anomaly.unit} vs{' '}
+            {anomaly.previousValue.toLocaleString()} {anomaly.unit} previously
+          </p>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="anomaly-mute-button"
+        onClick={onMute}
+        aria-label={`Mute alerts for ${anomaly.metricLabel}`}
+      >
+        <BellOff size={14} aria-hidden="true" />
+        Mute
+      </button>
+    </li>
+  );
+}


### PR DESCRIPTION
design: UsageBilling anomaly alerts panel

- Add UsageAnomalyPanel component: day-over-day / week-over-week
  usage anomaly rows with severity dot, delta chip, and plain-language
  reason line
- Add per-anomaly-type mute controls with a collapsible muted-types
  list and a header "Reset all mutes" control, persisted per user in
  localStorage
- Add threshold microcopy explaining when an anomaly is flagged
- Wire the panel into src/pages/UsageBilling.tsx with mock anomaly data
- WCAG 2.1 AA: severity/delta conveyed via text (not color alone),
  aria-live announcements for mute/unmute/reset, RTL-safe flex layout
- Add UsageAnomalyPanel.test.tsx (13 tests): rendering, accessible
  labels, mute/unmute/reset flows, empty and all-muted states,
  per-user persistence, malformed-storage recovery, RTL rendering
- Add docs/USAGE_ANOMALY_PANEL.md design spec


closes #404
