### PR TITLE
feat: add whitelabel live theme preview (#378)

### DIFF
--- a/src/components/settings/ThemePreview.css
+++ b/src/components/settings/ThemePreview.css
@@ -1,0 +1,214 @@
+@import '../../styles/tokens.css';
+
+.theme-preview {
+  width: 100%;
+}
+
+.theme-preview__layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  align-items: start;
+}
+
+.theme-preview__editor {
+  background: var(--color-surface-card);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-2xl);
+  padding: var(--space-5);
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.theme-preview__editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.theme-preview__editor-title {
+  font-family: var(--font-family-display);
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.theme-preview__editor-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.theme-preview__fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.theme-preview__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.theme-preview__field-label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+}
+
+.theme-preview__color-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.theme-preview__color-swatch {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  flex-shrink: 0;
+}
+
+.theme-preview__color-swatch::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.theme-preview__color-swatch::-webkit-color-swatch {
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+}
+
+.theme-preview__color-swatch::-moz-color-swatch {
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+}
+
+.theme-preview__text-input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-control);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-mono);
+  font-size: var(--text-xs);
+  outline: none;
+  transition: border-color 150ms ease;
+}
+
+.theme-preview__text-input:focus {
+  border-color: var(--color-focus-ring);
+  box-shadow: 0 0 0 3px var(--focus-ring-halo);
+}
+
+.theme-preview__viewport {
+  background: var(--color-surface-card);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.theme-preview__viewport-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-subtle);
+}
+
+.theme-preview__view-tabs {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.theme-preview__view-tab {
+  padding: var(--space-1) var(--space-3);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-family-body);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.theme-preview__view-tab:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-control-hover);
+}
+
+.theme-preview__view-tab--active {
+  background: var(--color-surface-elevated);
+  color: var(--color-brand-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.theme-preview__view-tab:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.theme-preview__refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-control);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.theme-preview__refresh-btn:hover {
+  background: var(--color-surface-control-hover);
+  color: var(--color-text-primary);
+}
+
+.theme-preview__refresh-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.theme-preview__iframe-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: var(--color-surface-canvas);
+}
+
+.theme-preview__iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+@media (max-width: 900px) {
+  .theme-preview__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .theme-preview__editor {
+    max-height: none;
+  }
+}

--- a/src/components/settings/ThemePreview.tsx
+++ b/src/components/settings/ThemePreview.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Download, RotateCcw } from 'lucide-react';
+import type { ThemeTokens } from '../../types/theme';
+import { DEFAULT_THEME_TOKENS } from '../../types/theme';
+import { PREVIEW_HTML } from './previewTemplate';
+import Button from '../common/Button';
+import './ThemePreview.css';
+
+type PreviewView = 'checkout' | 'dashboard' | 'receipt';
+
+interface ThemePreviewProps {
+  tokens: ThemeTokens;
+  onChange: (tokens: ThemeTokens) => void;
+}
+
+const TOKEN_FIELDS: { key: keyof ThemeTokens; label: string; type: 'color' | 'text' }[] = [
+  { key: 'primaryColor', label: 'Primary', type: 'color' },
+  { key: 'secondaryColor', label: 'Secondary', type: 'color' },
+  { key: 'backgroundColor', label: 'Background', type: 'color' },
+  { key: 'surfaceColor', label: 'Surface', type: 'color' },
+  { key: 'textColor', label: 'Text', type: 'color' },
+  { key: 'mutedTextColor', label: 'Muted Text', type: 'color' },
+  { key: 'accentColor', label: 'Accent', type: 'color' },
+  { key: 'successColor', label: 'Success', type: 'color' },
+  { key: 'dangerColor', label: 'Danger', type: 'color' },
+  { key: 'borderColor', label: 'Border', type: 'color' },
+  { key: 'inputBg', label: 'Input BG', type: 'color' },
+  { key: 'cardBg', label: 'Card BG', type: 'color' },
+  { key: 'fontFamily', label: 'Body Font', type: 'text' },
+  { key: 'headingFontFamily', label: 'Heading Font', type: 'text' },
+  { key: 'borderRadius', label: 'Border Radius', type: 'text' },
+];
+
+const VIEW_LABELS: Record<PreviewView, string> = {
+  checkout: 'Checkout',
+  dashboard: 'Dashboard',
+  receipt: 'Receipt',
+};
+
+function createPreviewBlob(): string {
+  return URL.createObjectURL(new Blob([PREVIEW_HTML], { type: 'text/html' }));
+}
+
+export default function ThemePreview({ tokens, onChange }: ThemePreviewProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [previewUrl, setPreviewUrl] = useState<string>(() => createPreviewBlob());
+  const [activeView, setActiveView] = useState<PreviewView>('checkout');
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const postToIframe = useCallback((data: unknown) => {
+    if (iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(data, '*');
+    }
+  }, []);
+
+  const handleMessage = useCallback((event: MessageEvent) => {
+    if (event.data?.type === 'preview-ready') {
+      setReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [handleMessage]);
+
+  useEffect(() => {
+    if (ready) {
+      postToIframe({ type: 'theme-tokens', tokens });
+    }
+  }, [ready, tokens, postToIframe]);
+
+  useEffect(() => {
+    if (ready) {
+      postToIframe({ type: 'switch-view', view: activeView });
+    }
+  }, [ready, activeView, postToIframe]);
+
+  const handleTokenChange = useCallback(
+    (key: keyof ThemeTokens, value: string) => {
+      onChange({ ...tokens, [key]: value });
+    },
+    [tokens, onChange],
+  );
+
+  const handleReset = useCallback(() => {
+    onChange(DEFAULT_THEME_TOKENS);
+  }, [onChange]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([JSON.stringify(tokens, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'theme-tokens.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [tokens]);
+
+  const handleRefreshPreview = useCallback(() => {
+    URL.revokeObjectURL(previewUrl);
+    const newUrl = createPreviewBlob();
+    setPreviewUrl(newUrl);
+    setReady(false);
+  }, [previewUrl]);
+
+  return (
+    <div className="theme-preview">
+      <div className="theme-preview__layout">
+        <div className="theme-preview__editor">
+          <div className="theme-preview__editor-header">
+            <h3 className="theme-preview__editor-title">Theme Tokens</h3>
+            <div className="theme-preview__editor-actions">
+              <Button variant="ghost" onClick={handleReset} leftIcon={<RotateCcw size={14} />}>
+                Reset
+              </Button>
+              <Button variant="outline" onClick={handleDownload} leftIcon={<Download size={14} />}>
+                Download
+              </Button>
+            </div>
+          </div>
+
+          <div className="theme-preview__fields">
+            {TOKEN_FIELDS.map((field) => (
+              <div key={field.key} className="theme-preview__field">
+                <label className="theme-preview__field-label">{field.label}</label>
+                {field.type === 'color' ? (
+                  <div className="theme-preview__color-input-wrap">
+                    <input
+                      type="color"
+                      className="theme-preview__color-swatch"
+                      value={tokens[field.key]}
+                      onChange={(e) => handleTokenChange(field.key, e.target.value)}
+                      aria-label={field.label}
+                    />
+                    <input
+                      type="text"
+                      className="theme-preview__text-input"
+                      value={tokens[field.key]}
+                      onChange={(e) => handleTokenChange(field.key, e.target.value)}
+                      aria-label={`${field.label} value`}
+                    />
+                  </div>
+                ) : (
+                  <input
+                    type="text"
+                    className="theme-preview__text-input"
+                    value={tokens[field.key]}
+                    onChange={(e) => handleTokenChange(field.key, e.target.value)}
+                    aria-label={field.label}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="theme-preview__viewport">
+          <div className="theme-preview__viewport-header">
+            <div className="theme-preview__view-tabs" role="tablist">
+              {(Object.keys(VIEW_LABELS) as PreviewView[]).map((view) => (
+                <button
+                  key={view}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeView === view}
+                  className={`theme-preview__view-tab${activeView === view ? ' theme-preview__view-tab--active' : ''}`}
+                  onClick={() => setActiveView(view)}
+                >
+                  {VIEW_LABELS[view]}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="theme-preview__refresh-btn"
+              onClick={handleRefreshPreview}
+              aria-label="Refresh preview"
+              title="Refresh preview"
+            >
+              <RotateCcw size={14} />
+            </button>
+          </div>
+
+          <div className="theme-preview__iframe-wrap">
+            <iframe
+              ref={iframeRef}
+              src={previewUrl}
+              className="theme-preview__iframe"
+              title="White-label theme preview"
+              sandbox="allow-scripts allow-same-origin"
+              tabIndex={-1}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/previewTemplate.ts
+++ b/src/components/settings/previewTemplate.ts
@@ -1,0 +1,465 @@
+export const PREVIEW_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Theme Preview</title>
+<style>
+  :root {
+    --primary: #22d3ee;
+    --secondary: #14b8a6;
+    --bg: #020617;
+    --surface: #0a0f16;
+    --text: #f8fafc;
+    --text-muted: #94a3b8;
+    --accent: #2dd4bf;
+    --success: #34d399;
+    --danger: #f87171;
+    --font: 'DM Sans', 'Sora', sans-serif;
+    --font-heading: 'Sora', 'DM Sans', sans-serif;
+    --radius: 0.75rem;
+    --border: rgba(148,163,184,0.16);
+    --input-bg: rgba(148,163,184,0.10);
+    --card-bg: #0a0f16;
+  }
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+    padding: 16px;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .preview-container {
+    max-width: 480px;
+    margin: 0 auto;
+  }
+
+  .view-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 16px;
+    background: var(--surface);
+    border-radius: var(--radius);
+    padding: 4px;
+    border: 1px solid var(--border);
+  }
+
+  .view-tab {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    border-radius: calc(var(--radius) - 2px);
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .view-tab:hover {
+    color: var(--text);
+    background: rgba(148,163,184,0.08);
+  }
+
+  .view-tab.active {
+    background: var(--card-bg);
+    color: var(--primary);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+  }
+
+  .view-panel {
+    display: none;
+  }
+
+  .view-panel.active {
+    display: block;
+  }
+
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    margin-bottom: 12px;
+  }
+
+  .card-title {
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: var(--text);
+  }
+
+  .form-group {
+    margin-bottom: 12px;
+  }
+
+  .form-group label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+  }
+
+  .form-input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--input-bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 0.9rem;
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .form-input:focus {
+    border-color: var(--primary);
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border: none;
+    border-radius: calc(var(--radius) - 2px);
+    font-family: var(--font);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, opacity 0.15s ease;
+  }
+
+  .btn-primary {
+    background: var(--primary);
+    color: #02131a;
+  }
+
+  .btn-primary:hover {
+    opacity: 0.9;
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+
+  .btn-secondary:hover {
+    background: rgba(148,163,184,0.08);
+  }
+
+  .btn-block {
+    width: 100%;
+  }
+
+  .kpi-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .kpi-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+  }
+
+  .kpi-label {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+  }
+
+  .kpi-value {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.2;
+  }
+
+  .kpi-delta {
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-top: 2px;
+  }
+
+  .kpi-delta.positive {
+    color: var(--success);
+  }
+
+  .kpi-delta.negative {
+    color: var(--danger);
+  }
+
+  .receipt {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+    text-align: center;
+  }
+
+  .receipt-header {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px dashed var(--border);
+  }
+
+  .receipt-merchant {
+    font-family: var(--font-heading);
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--text);
+  }
+
+  .receipt-amount {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text);
+    margin: 12px 0;
+  }
+
+  .receipt-amount .currency {
+    font-size: 1rem;
+    color: var(--text-muted);
+  }
+
+  .receipt-line {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .receipt-line .value {
+    color: var(--text);
+    font-weight: 500;
+  }
+
+  .receipt-total {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 0 0;
+    margin-top: 8px;
+    border-top: 1px solid var(--border);
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text);
+  }
+
+  .receipt-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 99px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(52,211,153,0.16);
+    color: var(--success);
+    margin-top: 12px;
+  }
+
+  .divider {
+    height: 1px;
+    background: var(--border);
+    margin: 12px 0;
+  }
+</style>
+</head>
+<body>
+<div class="preview-container">
+  <div class="view-tabs" role="tablist">
+    <button class="view-tab active" role="tab" aria-selected="true" data-view="checkout">Checkout</button>
+    <button class="view-tab" role="tab" aria-selected="false" data-view="dashboard">Dashboard</button>
+    <button class="view-tab" role="tab" aria-selected="false" data-view="receipt">Receipt</button>
+  </div>
+
+  <div id="view-checkout" class="view-panel active" role="tabpanel">
+    <div class="card">
+      <div class="card-title">Complete your purchase</div>
+      <div class="form-group">
+        <label>Card number</label>
+        <div class="form-input">4242 4242 4242 4242</div>
+      </div>
+      <div class="form-group">
+        <label>Expiry</label>
+        <div class="form-input">12/28</div>
+      </div>
+      <div class="form-group">
+        <label>CVC</label>
+        <div class="form-input">123</div>
+      </div>
+      <div class="divider"></div>
+      <div style="display:flex;justify-content:space-between;margin-bottom:12px;font-size:0.9rem">
+        <span style="color:var(--text-muted)">Pro Plan — Monthly</span>
+        <span style="font-weight:600;color:var(--text)">$29.00</span>
+      </div>
+      <button class="btn btn-primary btn-block">Pay $29.00</button>
+      <p style="text-align:center;margin-top:8px;font-size:0.75rem;color:var(--text-muted)">
+        Secured by Stellabill
+      </p>
+    </div>
+  </div>
+
+  <div id="view-dashboard" class="view-panel" role="tabpanel">
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <div class="kpi-label">Revenue</div>
+        <div class="kpi-value">$12,450</div>
+        <div class="kpi-delta positive">+8.2%</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">Subscribers</div>
+        <div class="kpi-value">1,342</div>
+        <div class="kpi-delta positive">+12</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">MRR</div>
+        <div class="kpi-value">$8.2k</div>
+        <div class="kpi-delta positive">+5.4%</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-label">Churn</div>
+        <div class="kpi-value">2.1%</div>
+        <div class="kpi-delta negative">-0.3%</div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-title">Recent transactions</div>
+      <div style="display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)">
+        <span style="font-size:0.85rem;color:var(--text-muted)">Acme Corp</span>
+        <span style="font-size:0.85rem;font-weight:500;color:var(--text)">$1,250.00</span>
+      </div>
+      <div style="display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)">
+        <span style="font-size:0.85rem;color:var(--text-muted)">Globex Inc</span>
+        <span style="font-size:0.85rem;font-weight:500;color:var(--text)">$890.50</span>
+      </div>
+      <div style="display:flex;justify-content:space-between;padding:8px 0">
+        <span style="font-size:0.85rem;color:var(--text-muted)">Initech</span>
+        <span style="font-size:0.85rem;font-weight:500;color:var(--text)">$2,100.00</span>
+      </div>
+    </div>
+  </div>
+
+  <div id="view-receipt" class="view-panel" role="tabpanel">
+    <div class="receipt">
+      <div class="receipt-header">
+        <div class="receipt-merchant">Stellabill</div>
+        <div style="font-size:0.75rem;color:var(--text-muted);margin-top:4px">receipt #SB-2024-8842</div>
+      </div>
+      <div class="receipt-amount">
+        <span class="currency">$</span>29.00
+      </div>
+      <div class="receipt-line">
+        <span>Pro Plan — Monthly</span>
+        <span class="value">$29.00</span>
+      </div>
+      <div class="receipt-line">
+        <span>Tax (0%)</span>
+        <span class="value">$0.00</span>
+      </div>
+      <div class="receipt-total">
+        <span>Total</span>
+        <span>$29.00</span>
+      </div>
+      <div class="receipt-line" style="margin-top:12px">
+        <span>Date</span>
+        <span class="value">Jul 29, 2026</span>
+      </div>
+      <div class="receipt-line">
+        <span>Card</span>
+        <span class="value">•••• 4242</span>
+      </div>
+      <div class="receipt-status">Paid</div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function() {
+  function applyTokens(tokens) {
+    const root = document.documentElement;
+    const map = {
+      '--primary': tokens.primaryColor,
+      '--secondary': tokens.secondaryColor,
+      '--bg': tokens.backgroundColor,
+      '--surface': tokens.surfaceColor,
+      '--text': tokens.textColor,
+      '--text-muted': tokens.mutedTextColor,
+      '--accent': tokens.accentColor,
+      '--success': tokens.successColor,
+      '--danger': tokens.dangerColor,
+      '--font': tokens.fontFamily,
+      '--font-heading': tokens.headingFontFamily,
+      '--radius': tokens.borderRadius,
+      '--border': tokens.borderColor,
+      '--input-bg': tokens.inputBg,
+      '--card-bg': tokens.cardBg,
+    };
+    for (const [prop, value] of Object.entries(map)) {
+      if (value !== undefined && value !== null) {
+        root.style.setProperty(prop, value);
+      }
+    }
+  }
+
+  function switchView(view) {
+    document.querySelectorAll('.view-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.view-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.view-tab').forEach(t => t.setAttribute('aria-selected', 'false'));
+    const panel = document.getElementById('view-' + view);
+    const tab = document.querySelector('[data-view="' + view + '"]');
+    if (panel) panel.classList.add('active');
+    if (tab) { tab.classList.add('active'); tab.setAttribute('aria-selected', 'true'); }
+  }
+
+  document.querySelectorAll('.view-tab').forEach(function(tab) {
+    tab.addEventListener('click', function() {
+      switchView(this.getAttribute('data-view'));
+    });
+  });
+
+  window.addEventListener('message', function(event) {
+    try {
+      const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      if (data.type === 'theme-tokens' && data.tokens) {
+        applyTokens(data.tokens);
+      }
+      if (data.type === 'switch-view' && data.view) {
+        switchView(data.view);
+      }
+    } catch(e) {
+      /* ignore */
+    }
+  });
+
+  parent.postMessage({ type: 'preview-ready' }, '*');
+})();
+</script>
+</body>
+</html>`;

--- a/src/pages/BrandPack.tsx
+++ b/src/pages/BrandPack.tsx
@@ -2,6 +2,9 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Logo from '../components/Branding/Logo';
 import Icon from '../components/Branding/Icon';
 import { EmptyDashboard, NoTransactions } from '../components/Branding/Illustrations';
+import ThemePreview from '../components/settings/ThemePreview';
+import type { ThemeTokens } from '../types/theme';
+import { DEFAULT_THEME_TOKENS } from '../types/theme';
 
 type CropFrame = {
   x: number;
@@ -38,6 +41,7 @@ const BrandPack: React.FC = () => {
   const [cropFrame, setCropFrame] = useState<CropFrame>({ x: 20, y: 20, width: 60, height: 60 });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
+  const [themeTokens, setThemeTokens] = useState<ThemeTokens>(DEFAULT_THEME_TOKENS);
 
   useEffect(() => {
     return () => {
@@ -479,6 +483,14 @@ const BrandPack: React.FC = () => {
               </div>
             ))}
           </div>
+        </section>
+
+        <section className="space-y-8">
+          <h2 className="border-b border-slate-800 pb-2 text-2xl font-semibold">Live Theme Preview</h2>
+          <p className="text-sm text-slate-400">
+            Edit theme tokens on the left and see real-time updates in the preview pane. Toggle between checkout, dashboard, and receipt views.
+          </p>
+          <ThemePreview tokens={themeTokens} onChange={setThemeTokens} />
         </section>
 
         <section className="space-y-8">

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,0 +1,35 @@
+export interface ThemeTokens {
+  primaryColor: string;
+  secondaryColor: string;
+  backgroundColor: string;
+  surfaceColor: string;
+  textColor: string;
+  mutedTextColor: string;
+  accentColor: string;
+  successColor: string;
+  dangerColor: string;
+  fontFamily: string;
+  borderRadius: string;
+  headingFontFamily: string;
+  borderColor: string;
+  inputBg: string;
+  cardBg: string;
+}
+
+export const DEFAULT_THEME_TOKENS: ThemeTokens = {
+  primaryColor: '#22d3ee',
+  secondaryColor: '#14b8a6',
+  backgroundColor: '#020617',
+  surfaceColor: '#0a0f16',
+  textColor: '#f8fafc',
+  mutedTextColor: '#94a3b8',
+  accentColor: '#2dd4bf',
+  successColor: '#34d399',
+  dangerColor: '#f87171',
+  fontFamily: "'DM Sans', 'Sora', sans-serif",
+  borderRadius: '0.75rem',
+  headingFontFamily: "'Sora', 'DM Sans', sans-serif",
+  borderColor: 'rgba(148, 163, 184, 0.16)',
+  inputBg: 'rgba(148, 163, 184, 0.10)',
+  cardBg: '#0a0f16',
+};


### PR DESCRIPTION
Closes #378

---

Adds a live theme preview panel to the BrandPack settings page:\n- ThemeTokens type definitions with full color palette\n- ThemePreview component with checkout/dashboard/receipt view toggles\n- Real-time preview template rendering\n- Integrated into the BrandPack settings page