### PR TITLE
design: smart-retry schedule visualization

### DIFF
--- a/src/components/Dunning/RetryScheduleViz.css
+++ b/src/components/Dunning/RetryScheduleViz.css
@@ -1,0 +1,614 @@
+/* RetryScheduleViz — smart-retry schedule visualization
+   -------------------------------------------------------
+   Uses design-system tokens (tokens.css) wherever possible.
+   Supports RTL via logical properties and [dir=rtl] overrides.
+   Reduced-motion: disables all transitions/animations.
+   Forced-colors: explicit ButtonBorder/Highlight mapping.
+*/
+
+/* ─── Container ──────────────────────────────────────────── */
+
+.rsv {
+  container-type: inline-size;
+  width: 100%;
+}
+
+/* Header row: title + "why these times?" trigger */
+.rsv__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+  margin-block-end: var(--space-4, 1rem);
+  flex-wrap: wrap;
+}
+
+.rsv__title {
+  margin: 0;
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: var(--font-semibold, 600);
+  color: var(--color-text-primary, #f8fafc);
+  letter-spacing: var(--tracking-wide, 0.025em);
+  text-transform: uppercase;
+}
+
+/* ─── Timeline track ─────────────────────────────────────── */
+
+.rsv__track {
+  /* Horizontal scroll for long schedules; never clips chips */
+  overflow-x: auto;
+  /* Inset ring instead of outline to avoid clipping */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.25) transparent;
+  padding-block-end: var(--space-2, 0.5rem); /* space for scrollbar */
+
+  /* Snap-scroll for mobile swipe */
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rsv__track:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #22d3ee);
+  outline-offset: 2px;
+}
+
+/* Inner list */
+.rsv__list {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;                /* connector lines are part of each item */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: max-content; /* allow overflow-x */
+}
+
+/* ─── Attempt item ───────────────────────────────────────── */
+
+.rsv__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  scroll-snap-align: center;
+
+  /* Minimum tap target width so chips don't crowd */
+  min-width: 7rem; /* 112px */
+}
+
+/* Connector line between items (pseudo on all but last) */
+.rsv__item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: calc(var(--rsv-icon-size, 2rem) / 2);
+  /* start from right edge of icon */
+  inset-inline-start: calc(50% + var(--rsv-icon-size, 2rem) / 2);
+  /* stretch to right edge of next item's icon */
+  inset-inline-end: calc(-50% + var(--rsv-icon-size, 2rem) / 2);
+  height: 2px;
+  background: var(--rsv-connector-color, rgba(100, 116, 139, 0.35));
+  transition: background 200ms ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Connector dims behind failed items */
+.rsv__item--failed:not(:last-child)::after,
+.rsv__item--all-failed + .rsv__item:not(:last-child)::after {
+  background: rgba(248, 113, 113, 0.18);
+}
+
+/* Connector brightens into succeeded item */
+.rsv__item--succeeded:not(:last-child)::after {
+  background: rgba(52, 211, 153, 0.4);
+}
+
+/* ─── Chip (icon node) ───────────────────────────────────── */
+
+.rsv__chip {
+  --rsv-icon-size: 2rem;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--rsv-icon-size);
+  height: var(--rsv-icon-size);
+  border-radius: 50%;
+  border: 2px solid transparent;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    transform 150ms ease;
+  cursor: default;
+  z-index: 1;
+  flex-shrink: 0;
+}
+
+/* Status variants */
+.rsv__item--past .rsv__chip {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.3);
+  color: #94a3b8;
+}
+
+.rsv__item--upcoming .rsv__chip {
+  background: rgba(251, 191, 36, 0.12);
+  border-color: rgba(251, 191, 36, 0.5);
+  color: #fbbf24;
+  box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.08);
+}
+
+/* "Next" pulsing ring for the first upcoming attempt */
+.rsv__item--upcoming.rsv__item--next .rsv__chip::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid rgba(251, 191, 36, 0.35);
+  animation: rsv-pulse 2s ease-in-out infinite;
+}
+
+.rsv__item--failed .rsv__chip {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #f87171;
+}
+
+.rsv__item--succeeded .rsv__chip {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.45);
+  color: #34d399;
+}
+
+/* Hover — show subtle elevation when clickable popovers are attached */
+.rsv__chip:hover {
+  transform: scale(1.08);
+}
+
+/* Focus ring on chip wrapper when it has a button inside */
+.rsv__chip-btn {
+  all: unset;
+  /* Re-apply chip layout */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.rsv__chip-btn:focus-visible {
+  outline: 3px solid var(--color-focus-ring, #22d3ee);
+  outline-offset: 3px;
+  border-radius: 50%;
+  box-shadow: 0 0 10px rgba(34, 211, 238, 0.35);
+}
+
+/* ─── Labels under each chip ─────────────────────────────── */
+
+.rsv__labels {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin-block-start: var(--space-2, 0.5rem);
+  text-align: center;
+  max-width: 8rem;
+}
+
+/* Absolute date / time */
+.rsv__when {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: var(--font-semibold, 600);
+  color: var(--color-text-primary, #f8fafc);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+/* Relative delta: "+2 d", "now", "−3 h" */
+.rsv__delta {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--color-text-muted, #64748b);
+  line-height: 1.2;
+}
+
+/* Method badge: "card", "USDC", etc. */
+.rsv__method {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: var(--font-bold, 700);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider, 0.05em);
+  white-space: nowrap;
+  margin-block-start: var(--space-1, 0.25rem);
+}
+
+.rsv__method--card {
+  background: rgba(99, 102, 241, 0.14);
+  color: #818cf8;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.rsv__method--usdc {
+  background: rgba(14, 165, 164, 0.14);
+  color: #2dd4bf;
+  border: 1px solid rgba(14, 165, 164, 0.25);
+}
+
+.rsv__method--prepaid {
+  background: rgba(245, 158, 11, 0.14);
+  color: #fbbf24;
+  border: 1px solid rgba(245, 158, 11, 0.25);
+}
+
+.rsv__method--bank {
+  background: rgba(96, 165, 250, 0.14);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.25);
+}
+
+.rsv__method--other {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94a3b8;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+/* Success probability bar */
+.rsv__prob-track {
+  width: 100%;
+  max-width: 4.5rem;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+  margin-block-start: var(--space-1, 0.25rem);
+}
+
+.rsv__prob-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 400ms ease;
+}
+
+.rsv__prob-fill--high   { background: #34d399; }
+.rsv__prob-fill--medium { background: #fbbf24; }
+.rsv__prob-fill--low    { background: #f87171; }
+
+/* Probability label (visually hidden, accessible via aria-label) */
+.rsv__prob-label {
+  font-size: 10px;
+  color: var(--color-text-muted, #64748b);
+  line-height: 1;
+}
+
+/* ─── Status badge ───────────────────────────────────────── */
+
+.rsv__status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: var(--font-bold, 700);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider, 0.05em);
+  white-space: nowrap;
+  margin-block-start: var(--space-1, 0.25rem);
+}
+
+.rsv__status-badge--past     { background: rgba(148,163,184,0.1); color: #94a3b8; border: 1px solid rgba(148,163,184,0.2); }
+.rsv__status-badge--failed   { background: rgba(248,113,113,0.1); color: #f87171; border: 1px solid rgba(248,113,113,0.25); }
+.rsv__status-badge--succeeded{ background: rgba(52,211,153,0.1);  color: #34d399; border: 1px solid rgba(52,211,153,0.25); }
+.rsv__status-badge--upcoming { background: rgba(251,191,36,0.1);  color: #fbbf24; border: 1px solid rgba(251,191,36,0.25); }
+
+/* ─── Empty / all-failed callout ─────────────────────────── */
+
+.rsv__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+  padding: var(--space-6, 1.5rem) var(--space-4, 1rem);
+  border-radius: 10px;
+  background: rgba(248, 113, 113, 0.07);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+  text-align: center;
+}
+
+.rsv__empty-icon {
+  color: #f87171;
+}
+
+.rsv__empty-title {
+  margin: 0;
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: var(--font-semibold, 600);
+  color: #f87171;
+}
+
+.rsv__empty-body {
+  margin: 0;
+  font-size: var(--text-xs, 0.75rem);
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+/* ─── "Show more" overflow control ───────────────────────── */
+
+.rsv__overflow-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+  margin-block-start: var(--space-3, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: var(--font-semibold, 600);
+  color: #60a5fa;
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+
+.rsv__overflow-btn:hover  { color: #93c5fd; }
+
+.rsv__overflow-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring, #22d3ee);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ─── Why popover (FieldHelpPopover pattern) ─────────────── */
+
+.rsv__why-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.rsv__why-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: var(--font-medium, 500);
+  color: var(--color-text-muted, #64748b);
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 2px var(--space-2, 0.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+.rsv__why-btn:hover,
+.rsv__why-btn[aria-expanded="true"] {
+  color: #67d5f0;
+  border-color: rgba(103, 213, 240, 0.35);
+  background: rgba(103, 213, 240, 0.08);
+}
+
+.rsv__why-btn:focus-visible {
+  outline: 3px solid var(--color-focus-ring, #22d3ee);
+  outline-offset: 2px;
+  box-shadow: 0 0 10px rgba(34, 211, 238, 0.35);
+}
+
+.rsv__why-popover {
+  position: absolute;
+  /* Opens upward by default; if not enough space, JS flips it */
+  inset-block-end: calc(100% + 0.5rem);
+  inset-inline-start: 0;
+  z-index: var(--z-dropdown, 100);
+  width: min(22rem, calc(100vw - 2rem));
+  padding: var(--space-4, 1rem);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 10px;
+  background: #06111d;
+  color: #cbd5e1;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.rsv__why-popover--below {
+  inset-block-end: auto;
+  inset-block-start: calc(100% + 0.5rem);
+}
+
+.rsv__why-popover:focus {
+  outline: none;
+}
+
+.rsv__why-title {
+  margin: 0 0 var(--space-3, 0.75rem);
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: var(--font-bold, 700);
+  color: #f8fafc;
+}
+
+.rsv__why-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+}
+
+.rsv__why-item {
+  display: grid;
+  grid-template-columns: 1.5rem 1fr;
+  gap: var(--space-2, 0.5rem);
+  align-items: start;
+}
+
+.rsv__why-icon {
+  display: inline-flex;
+  color: #0ea5e9;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.rsv__why-text {
+  font-size: var(--text-xs, 0.75rem);
+  line-height: 1.55;
+  color: #94a3b8;
+}
+
+.rsv__why-text strong {
+  display: block;
+  color: #e2e8f0;
+  font-weight: var(--font-semibold, 600);
+  margin-block-end: 2px;
+}
+
+.rsv__why-close {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  margin-block-start: var(--space-3, 0.75rem);
+  min-height: 2rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 6px;
+  background: transparent;
+  color: #e2e8f0;
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: var(--font-semibold, 600);
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.rsv__why-close:hover {
+  border-color: rgba(103, 213, 240, 0.35);
+  color: #67d5f0;
+}
+
+.rsv__why-close:focus-visible {
+  outline: 3px solid var(--color-focus-ring, #22d3ee);
+  outline-offset: 2px;
+}
+
+/* ─── SR-only live region ─────────────────────────────────── */
+
+.rsv__sr-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─── RTL ────────────────────────────────────────────────── */
+
+[dir="rtl"] .rsv__list {
+  flex-direction: row-reverse;
+}
+
+/* Connector lines already use logical inset-inline-* so they flip automatically */
+
+/* ─── Responsive (container queries) ────────────────────── */
+
+/* Below ~480px: stack vertically */
+@container (max-width: 30rem) {
+  .rsv__list {
+    flex-direction: column;
+    min-width: unset;
+    gap: var(--space-4, 1rem);
+    align-items: flex-start;
+  }
+
+  .rsv__item {
+    flex-direction: row;
+    align-items: flex-start;
+    min-width: unset;
+    width: 100%;
+    gap: var(--space-3, 0.75rem);
+  }
+
+  /* No horizontal connector in vertical layout */
+  .rsv__item:not(:last-child)::after {
+    content: none;
+  }
+
+  /* Vertical connector instead */
+  .rsv__item:not(:last-child)::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: calc(var(--rsv-icon-size, 2rem) / 2 - 1px);
+    top: var(--rsv-icon-size, 2rem);
+    bottom: calc(-1 * var(--space-4, 1rem));
+    width: 2px;
+    background: rgba(100, 116, 139, 0.25);
+  }
+
+  .rsv__labels {
+    align-items: flex-start;
+    text-align: start;
+    max-width: none;
+    margin-block-start: 0;
+  }
+
+  [dir="rtl"] .rsv__list {
+    flex-direction: column;
+  }
+}
+
+/* ─── Animations ─────────────────────────────────────────── */
+
+@keyframes rsv-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50%       { opacity: 0.8; transform: scale(1.15); }
+}
+
+/* ─── Reduced motion ─────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .rsv__chip,
+  .rsv__chip:hover,
+  .rsv__prob-fill,
+  .rsv__why-btn,
+  .rsv__overflow-btn {
+    transition: none;
+  }
+
+  .rsv__item--upcoming.rsv__item--next .rsv__chip::before {
+    animation: none;
+    opacity: 0.45;
+  }
+}
+
+/* ─── Forced colors (Windows HCM) ────────────────────────── */
+
+@media (forced-colors: active) {
+  .rsv__chip {
+    border-color: ButtonBorder;
+    background: ButtonFace;
+    color: ButtonText;
+  }
+
+  .rsv__chip-btn:focus-visible,
+  .rsv__why-btn:focus-visible,
+  .rsv__overflow-btn:focus-visible,
+  .rsv__why-close:focus-visible {
+    outline: 3px solid Highlight;
+    box-shadow: none;
+  }
+
+  .rsv__why-popover {
+    border-color: ButtonBorder;
+    background: Canvas;
+    color: CanvasText;
+  }
+
+  .rsv__prob-fill { background: ButtonText; }
+  .rsv__item--upcoming.rsv__item--next .rsv__chip::before { display: none; }
+}

--- a/src/components/Dunning/RetryScheduleViz.test.tsx
+++ b/src/components/Dunning/RetryScheduleViz.test.tsx
@@ -1,0 +1,650 @@
+/**
+ * RetryScheduleViz tests
+ * ----------------------
+ * Coverage target: ≥ 95 %
+ *
+ * Covers:
+ *  - Basic rendering of chips, labels, delta, method badges, probability bars
+ *  - Status variants: past / upcoming / failed / succeeded
+ *  - "Next" chip pulsing ring (aria-current)
+ *  - Empty-schedule state
+ *  - All-failed state
+ *  - "Why these times?" popover (open, close via button / Escape / outside-click)
+ *  - Focus management inside the popover
+ *  - Show-more / show-less overflow toggle
+ *  - SR live-region messages
+ *  - RTL direction (data-dir attribute propagation)
+ *  - Label overrides
+ *  - Custom whyContent slot
+ *  - RetryTimeline backward-compatibility wrapper
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import RetryScheduleViz, {
+  type RetryAttempt,
+  type RetryScheduleVizProps,
+} from './RetryScheduleViz';
+import RetryTimeline from './RetryTimeline';
+
+// ─── Fixtures ───────────────────────────────────────────────
+
+const NOW_ISO = '2026-03-22T10:00:00.000Z';
+
+/** Freezes Date.now / new Date() so delta computations are stable */
+function freezeDate(iso = NOW_ISO) {
+  const fixed = new Date(iso);
+  vi.useFakeTimers();
+  vi.setSystemTime(fixed);
+}
+
+/** Restore real timers after every test so fake timers don't leak */
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const attempt = (
+  overrides: Partial<RetryAttempt> & Pick<RetryAttempt, 'id' | 'when' | 'status'>,
+): RetryAttempt => ({
+  scheduledAt: new Date().toISOString(),
+  ...overrides,
+});
+
+/** A typical 4-attempt schedule (1 failed, 1 past, 1 upcoming, 1 future) */
+const TYPICAL_ATTEMPTS: RetryAttempt[] = [
+  {
+    id: 'a1',
+    when: 'Mar 20, 08:00',
+    scheduledAt: '2026-03-20T08:00:00Z',
+    status: 'failed',
+    method: 'card',
+    successProbability: 0.1,
+  },
+  {
+    id: 'a2',
+    when: 'Mar 21, 08:00',
+    scheduledAt: '2026-03-21T08:00:00Z',
+    status: 'past',
+    method: 'card',
+    successProbability: 0.3,
+  },
+  {
+    id: 'a3',
+    when: 'Mar 22, 14:00',
+    scheduledAt: '2026-03-22T14:00:00Z',
+    status: 'upcoming',
+    method: 'usdc',
+    successProbability: 0.7,
+  },
+  {
+    id: 'a4',
+    when: 'Mar 23, 06:00',
+    scheduledAt: '2026-03-23T06:00:00Z',
+    status: 'upcoming',
+    method: 'prepaid',
+    successProbability: 0.45,
+  },
+];
+
+function renderViz(props: RetryScheduleVizProps) {
+  return render(<RetryScheduleViz {...props} />);
+}
+
+// ─── Basic rendering ────────────────────────────────────────
+
+describe('RetryScheduleViz – basic rendering', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('renders the outer wrapper with data-testid', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByTestId('retry-schedule-viz')).toBeInTheDocument();
+  });
+
+  it('renders a title heading', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByRole('heading', { name: /retry schedule/i })).toBeInTheDocument();
+  });
+
+  it('renders one list item per visible attempt', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    // Default maxVisible = 5, all 4 attempts are shown
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(4);
+  });
+
+  it('renders the scheduled date for each attempt', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByText('Mar 20, 08:00')).toBeInTheDocument();
+    expect(screen.getByText('Mar 22, 14:00')).toBeInTheDocument();
+  });
+
+  it('renders <time> elements with correct dateTime attribute', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const times = document.querySelectorAll('time');
+    const dateTimes = Array.from(times).map((t) => t.getAttribute('dateTime'));
+    expect(dateTimes).toContain('2026-03-20T08:00:00Z');
+    expect(dateTimes).toContain('2026-03-22T14:00:00Z');
+  });
+});
+
+// ─── Method badges ───────────────────────────────────────────
+
+describe('RetryScheduleViz – method badges', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('renders method badge with correct label', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    // a3 has method=usdc
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+    // a4 has method=prepaid
+    expect(screen.getByText('Prepaid')).toBeInTheDocument();
+  });
+
+  it('does not render method badge when method is absent', () => {
+    const noMethodAttempts: RetryAttempt[] = [
+      { id: 'x', when: 'Apr 1', scheduledAt: '2026-04-01T00:00:00Z', status: 'upcoming' },
+    ];
+    renderViz({ attempts: noMethodAttempts });
+    // No method badges
+    expect(screen.queryByText('Card')).not.toBeInTheDocument();
+    expect(screen.queryByText('USDC')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['card', 'Card'],
+    ['usdc', 'USDC'],
+    ['prepaid', 'Prepaid'],
+    ['bank', 'Bank'],
+    ['other', 'Other'],
+  ] as const)('renders %s method badge as "%s"', (method, label) => {
+    renderViz({
+      attempts: [{ id: '1', when: 'Now', scheduledAt: NOW_ISO, status: 'upcoming', method }],
+    });
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});
+
+// ─── Status variants ─────────────────────────────────────────
+
+describe('RetryScheduleViz – status badges', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it.each([
+    ['past', 'Attempted'],
+    ['upcoming', 'Upcoming'],
+    ['succeeded', 'Succeeded'],
+  ] as const)('renders "%s" status as "%s"', (status, label) => {
+    renderViz({
+      attempts: [{ id: '1', when: 'Now', scheduledAt: NOW_ISO, status }],
+    });
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('renders "failed" status badge when at least one non-failed attempt exists', () => {
+    // A single failed attempt triggers the all-failed empty state.
+    // Mix failed + upcoming so the timeline renders chips.
+    renderViz({
+      attempts: [
+        { id: 'f1', when: 'Mar 20', scheduledAt: '2026-03-20T00:00:00Z', status: 'failed' },
+        { id: 'u1', when: 'Mar 22', scheduledAt: NOW_ISO, status: 'upcoming' },
+      ],
+    });
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+});
+
+// ─── Success probability ────────────────────────────────────
+
+describe('RetryScheduleViz – success probability', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('renders a meter for each attempt with successProbability', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const meters = screen.getAllByRole('meter');
+    // 4 attempts all have successProbability
+    expect(meters).toHaveLength(4);
+  });
+
+  it('sets aria-valuenow correctly on probability meter', () => {
+    renderViz({
+      attempts: [
+        { id: '1', when: 'Now', scheduledAt: NOW_ISO, status: 'upcoming', successProbability: 0.72 },
+      ],
+    });
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '72');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('hides probability bar when successProbability is absent', () => {
+    renderViz({
+      attempts: [{ id: '1', when: 'Now', scheduledAt: NOW_ISO, status: 'upcoming' }],
+    });
+    expect(screen.queryByRole('meter')).not.toBeInTheDocument();
+  });
+});
+
+// ─── "Next" chip ─────────────────────────────────────────────
+
+describe('RetryScheduleViz – "next" upcoming chip', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('marks the first upcoming item with aria-current', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    const items = within(list).getAllByRole('listitem');
+    // a3 is the first upcoming (index 2)
+    expect(items[2]).toHaveAttribute('aria-current', 'true');
+    // a4 is also upcoming but not "next"
+    expect(items[3]).not.toHaveAttribute('aria-current');
+  });
+
+  it('does not set aria-current when there is no upcoming attempt', () => {
+    const allPast: RetryAttempt[] = [
+      { id: 'a1', when: 'Mar 20', scheduledAt: '2026-03-20T00:00:00Z', status: 'past' },
+      { id: 'a2', when: 'Mar 21', scheduledAt: '2026-03-21T00:00:00Z', status: 'past' },
+    ];
+    renderViz({ attempts: allPast });
+    const items = screen.getAllByRole('listitem');
+    items.forEach((item) => expect(item).not.toHaveAttribute('aria-current'));
+  });
+});
+
+// ─── Screen-reader live region ───────────────────────────────
+
+describe('RetryScheduleViz – SR live region', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('announces next-attempt time when there is an upcoming attempt', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const live = screen.getByRole('status');
+    expect(live).toHaveTextContent('Next payment retry scheduled for Mar 22, 14:00');
+  });
+
+  it('announces all-failed message when every attempt is failed', () => {
+    const allFailed: RetryAttempt[] = [
+      { id: 'f1', when: 'Mar 20', scheduledAt: '2026-03-20T00:00:00Z', status: 'failed' },
+      { id: 'f2', when: 'Mar 21', scheduledAt: '2026-03-21T00:00:00Z', status: 'failed' },
+    ];
+    renderViz({ attempts: allFailed });
+    const live = screen.getByRole('status');
+    expect(live).toHaveTextContent(/all retry attempts have failed/i);
+  });
+
+  it('announces no-schedule message when attempts array is empty', () => {
+    renderViz({ attempts: [] });
+    const live = screen.getByRole('status');
+    expect(live).toHaveTextContent(/no retry schedule/i);
+  });
+});
+
+// ─── Empty / all-failed state ────────────────────────────────
+
+describe('RetryScheduleViz – empty and all-failed states', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('shows the empty callout when attempts array is empty', () => {
+    renderViz({ attempts: [] });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/all retries exhausted/i)).toBeInTheDocument();
+  });
+
+  it('shows the empty callout when all attempts have failed', () => {
+    const allFailed: RetryAttempt[] = [
+      { id: 'f1', when: 'Mar 20', scheduledAt: '2026-03-20T00:00:00Z', status: 'failed' },
+    ];
+    renderViz({ attempts: allFailed });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('does NOT show the timeline list in the all-failed state', () => {
+    const allFailed: RetryAttempt[] = [
+      { id: 'f1', when: 'Mar 20', scheduledAt: '2026-03-20T00:00:00Z', status: 'failed' },
+    ];
+    renderViz({ attempts: allFailed });
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('shows the timeline list when at least one attempt is not failed', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByRole('list', { name: /retry schedule/i })).toBeInTheDocument();
+  });
+});
+
+// ─── Overflow / show-more ────────────────────────────────────
+
+describe('RetryScheduleViz – overflow show-more toggle', () => {
+  // No fake timers here — userEvent needs real timers to resolve
+
+  const manyAttempts: RetryAttempt[] = Array.from({ length: 8 }, (_, i) => ({
+    id: `a${i}`,
+    when: `Mar ${20 + i}`,
+    scheduledAt: new Date(Date.UTC(2026, 2, 20 + i)).toISOString(),
+    status: i < 5 ? ('past' as const) : ('upcoming' as const),
+  }));
+
+  it('caps visible items at maxVisible', () => {
+    renderViz({ attempts: manyAttempts, maxVisible: 3 });
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('renders the "show more" button with correct count', () => {
+    renderViz({ attempts: manyAttempts, maxVisible: 5 });
+    const btn = screen.getByRole('button', { name: /show all attempts/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('3 more');
+  });
+
+  it('shows all items after clicking "show more"', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: manyAttempts, maxVisible: 5 });
+    await user.click(screen.getByRole('button', { name: /show all attempts/i }));
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(8);
+  });
+
+  it('renders "show less" button after expanding', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: manyAttempts, maxVisible: 5 });
+    await user.click(screen.getByRole('button', { name: /show all attempts/i }));
+    expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
+  });
+
+  it('collapses back to maxVisible when "show less" is clicked', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: manyAttempts, maxVisible: 5 });
+    await user.click(screen.getByRole('button', { name: /show all attempts/i }));
+    await user.click(screen.getByRole('button', { name: /show less/i }));
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+  });
+
+  it('calls onShowMore callback when expanding', async () => {
+    const spy = vi.fn();
+    const user = userEvent.setup();
+    renderViz({ attempts: manyAttempts, maxVisible: 5, onShowMore: spy });
+    await user.click(screen.getByRole('button', { name: /show all attempts/i }));
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('does not show the overflow button when attempts ≤ maxVisible', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS, maxVisible: 10 });
+    expect(screen.queryByRole('button', { name: /show all attempts/i })).not.toBeInTheDocument();
+  });
+});
+
+// ─── "Why these times?" popover ──────────────────────────────
+
+describe('RetryScheduleViz – why-times popover', () => {
+  // No fake timers here — userEvent needs real timers to resolve
+
+  it('renders the "Why these times?" trigger button', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(
+      screen.getByRole('button', { name: /how we schedule retries/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the popover when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    expect(screen.getByRole('dialog', { name: /how we schedule retries/i })).toBeInTheDocument();
+  });
+
+  it('shows the default heuristic items inside the popover', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    expect(screen.getByText(/off-peak window/i)).toBeInTheDocument();
+    expect(screen.getByText(/exponential back-off/i)).toBeInTheDocument();
+    expect(screen.getByText(/success-probability model/i)).toBeInTheDocument();
+    expect(screen.getByText(/smart method rotation/i)).toBeInTheDocument();
+  });
+
+  it('closes the popover when "Got it" is clicked', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    await user.click(screen.getByRole('button', { name: /got it/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes the popover on Escape key', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes the popover when clicking outside', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <RetryScheduleViz attempts={TYPICAL_ATTEMPTS} />
+        <button type="button">Outside</button>
+      </div>,
+    );
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('focuses the "Got it" button when popover opens', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    const closeBtn = screen.getByRole('button', { name: /got it/i });
+    expect(closeBtn).toHaveFocus();
+  });
+
+  it('restores focus to trigger button after closing', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const trigger = screen.getByRole('button', { name: /how we schedule retries/i });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: /got it/i }));
+    expect(trigger).toHaveFocus();
+  });
+
+  it('traps focus within the popover (Tab stays inside)', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    const closeBtn = screen.getByRole('button', { name: /got it/i });
+    // Tab from only focusable element stays on it
+    await user.tab();
+    expect(closeBtn).toHaveFocus();
+  });
+
+  it('renders custom whyContent when provided', async () => {
+    const user = userEvent.setup();
+    renderViz({
+      attempts: TYPICAL_ATTEMPTS,
+      whyContent: <p>Custom explanation text</p>,
+    });
+    await user.click(screen.getByRole('button', { name: /how we schedule retries/i }));
+    expect(screen.getByText('Custom explanation text')).toBeInTheDocument();
+    // Default items should NOT appear
+    expect(screen.queryByText(/off-peak window/i)).not.toBeInTheDocument();
+  });
+
+  it('sets aria-expanded correctly on trigger', async () => {
+    const user = userEvent.setup();
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    const trigger = screen.getByRole('button', { name: /how we schedule retries/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+// ─── Label overrides ─────────────────────────────────────────
+
+describe('RetryScheduleViz – label overrides', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('uses custom title', () => {
+    renderViz({
+      attempts: TYPICAL_ATTEMPTS,
+      labels: { title: 'Custom title' },
+    });
+    expect(screen.getByRole('heading', { name: 'Custom title' })).toBeInTheDocument();
+  });
+
+  it('uses custom why-button text', () => {
+    renderViz({
+      attempts: TYPICAL_ATTEMPTS,
+      labels: { whyButton: 'Explain timing' },
+    });
+    expect(screen.getByText('Explain timing')).toBeInTheDocument();
+  });
+
+  it('uses custom SR next-attempt message', () => {
+    renderViz({
+      attempts: TYPICAL_ATTEMPTS,
+      labels: { srNextAttempt: (w) => `Next retry: ${w}` },
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Next retry: Mar 22, 14:00');
+  });
+
+  it('uses custom empty title', () => {
+    renderViz({
+      attempts: [],
+      labels: { emptyTitle: 'No more retries' },
+    });
+    expect(screen.getByText('No more retries')).toBeInTheDocument();
+  });
+});
+
+// ─── Relative delta ──────────────────────────────────────────
+
+describe('RetryScheduleViz – relative delta computation', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('shows "+4 h" for an attempt 4 hours in the future', () => {
+    freezeDate('2026-03-22T10:00:00Z');
+    const futureAttempt: RetryAttempt[] = [
+      {
+        id: '1',
+        when: 'Mar 22, 14:00',
+        scheduledAt: '2026-03-22T14:00:00Z', // +4h
+        status: 'upcoming',
+      },
+    ];
+    renderViz({ attempts: futureAttempt });
+    expect(screen.getByText('+4 h')).toBeInTheDocument();
+  });
+
+  it('shows "−2 d" for an attempt 2 days in the past', () => {
+    freezeDate('2026-03-22T10:00:00Z');
+    const pastAttempt: RetryAttempt[] = [
+      {
+        id: '1',
+        when: 'Mar 20, 10:00',
+        scheduledAt: '2026-03-20T10:00:00Z', // −2d
+        status: 'past',
+      },
+    ];
+    renderViz({ attempts: pastAttempt });
+    expect(screen.getByText('−2 d')).toBeInTheDocument();
+  });
+
+  it('shows "now" for an attempt very close to the current time', () => {
+    const close = new Date();
+    close.setSeconds(close.getSeconds() + 5);
+    freezeDate();
+    const nowAttempt: RetryAttempt[] = [
+      { id: '1', when: 'Now', scheduledAt: close.toISOString(), status: 'upcoming' },
+    ];
+    renderViz({ attempts: nowAttempt });
+    expect(screen.getByText('now')).toBeInTheDocument();
+  });
+});
+
+// ─── RTL ─────────────────────────────────────────────────────
+
+describe('RetryScheduleViz – RTL layout', () => {
+  it('renders without errors in an RTL document', () => {
+    document.documentElement.setAttribute('dir', 'rtl');
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByTestId('retry-schedule-viz')).toBeInTheDocument();
+    document.documentElement.removeAttribute('dir');
+  });
+});
+
+// ─── RetryTimeline wrapper (backward compat) ─────────────────
+
+describe('RetryTimeline (backward-compat wrapper)', () => {
+  it('renders using the original simple attempt shape', () => {
+    const simpleAttempts = [
+      { id: 'a1', when: 'Mar 20', status: 'past' as const },
+      { id: 'a2', when: 'Mar 22', status: 'upcoming' as const },
+    ];
+    render(<RetryTimeline attempts={simpleAttempts} />);
+    expect(screen.getByTestId('retry-schedule-viz')).toBeInTheDocument();
+    expect(screen.getByText('Mar 20')).toBeInTheDocument();
+    expect(screen.getByText('Mar 22')).toBeInTheDocument();
+  });
+
+  it('passes maxVisible through to RetryScheduleViz', () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      id: `x${i}`,
+      when: `Apr ${i + 1}`,
+      status: 'upcoming' as const,
+    }));
+    render(<RetryTimeline attempts={many} maxVisible={3} />);
+    const list = screen.getByRole('list', { name: /retry schedule/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('passes optional method and successProbability fields', () => {
+    const attempts = [
+      {
+        id: 'r1',
+        when: 'Mar 22',
+        status: 'upcoming' as const,
+        method: 'usdc' as const,
+        successProbability: 0.8,
+      },
+    ];
+    render(<RetryTimeline attempts={attempts} />);
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+    expect(screen.getByRole('meter')).toBeInTheDocument();
+  });
+
+  it('renders legacy list with aria-label for the region', () => {
+    const simpleAttempts = [
+      { id: 'a1', when: 'Mar 20', status: 'past' as const },
+    ];
+    render(<RetryTimeline attempts={simpleAttempts} />);
+    expect(screen.getByRole('list', { name: /retry schedule/i })).toBeInTheDocument();
+  });
+});
+
+// ─── Accessibility: roles and attributes ────────────────────
+
+describe('RetryScheduleViz – ARIA attributes', () => {
+  beforeEach(() => { freezeDate(); });
+
+  it('has a region with accessible name for the track', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByRole('region', { name: /retry schedule/i })).toBeInTheDocument();
+  });
+
+  it('list has accessible name', () => {
+    renderViz({ attempts: TYPICAL_ATTEMPTS });
+    expect(screen.getByRole('list', { name: /retry schedule/i })).toBeInTheDocument();
+  });
+
+  it('probability meters have accessible name with percentage', () => {
+    renderViz({ attempts: [
+      { id: 'p1', when: 'Now', scheduledAt: NOW_ISO, status: 'upcoming', successProbability: 0.72 },
+    ] });
+    expect(screen.getByRole('meter', { name: /72%/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/Dunning/RetryScheduleViz.tsx
+++ b/src/components/Dunning/RetryScheduleViz.tsx
@@ -1,0 +1,546 @@
+/**
+ * RetryScheduleViz
+ * ----------------
+ * Horizontal timeline that visualises a smart-retry dunning schedule.
+ *
+ * Features
+ * - Per-attempt chip showing status, absolute date, relative delta,
+ *   payment method, and success-probability bar.
+ * - "Why these times?" popover explaining the scheduling heuristics.
+ * - Screen-reader live region announcing the next-attempt time.
+ * - Handles edge cases: long schedules (overflow-x + "show more" cap),
+ *   all-failed, empty schedule, and RTL layouts.
+ * - WCAG 2.1 AA: focus-visible rings, ARIA roles/labels, reduced-motion
+ *   and forced-colours media queries.
+ * - Responsive via container queries: horizontal below 480 px switches
+ *   to vertical stacked layout.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import {
+  AlertTriangle,
+  BanknoteIcon,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  CreditCard,
+  HelpCircle,
+  Wallet,
+  X,
+  Zap,
+  TrendingUp,
+  BarChart2,
+  ShieldCheck,
+  CalendarClock,
+} from 'lucide-react';
+import { useModalFocus } from '../../hooks/useModalFocus';
+import './RetryScheduleViz.css';
+
+// ─── Types ──────────────────────────────────────────────────
+
+export type AttemptStatus = 'past' | 'upcoming' | 'failed' | 'succeeded';
+
+export type PaymentMethodKind =
+  | 'card'
+  | 'usdc'
+  | 'prepaid'
+  | 'bank'
+  | 'other';
+
+export interface RetryAttempt {
+  /** Unique identifier */
+  id: string;
+  /** ISO-8601 timestamp, e.g. "2026-03-22T09:00:00Z" */
+  scheduledAt: string;
+  /** Human-readable date label, e.g. "Mar 22, 09:00" */
+  when: string;
+  status: AttemptStatus;
+  /**
+   * Payment method used / to be used for this attempt.
+   * If omitted, the method badge is hidden.
+   */
+  method?: PaymentMethodKind;
+  /**
+   * Estimated success probability 0–1.
+   * Omit to hide the probability bar.
+   */
+  successProbability?: number;
+}
+
+export interface RetryScheduleVizProps {
+  attempts: RetryAttempt[];
+  /**
+   * Max chips shown before a "show more" toggle appears.
+   * Defaults to 5. Set to Infinity to disable.
+   */
+  maxVisible?: number;
+  /** Called when user expands beyond maxVisible */
+  onShowMore?: () => void;
+  /** Override the "why" popover content */
+  whyContent?: React.ReactNode;
+  /** i18n override for static strings */
+  labels?: Partial<RetryScheduleVizLabels>;
+}
+
+export interface RetryScheduleVizLabels {
+  title: string;
+  whyButton: string;
+  whyTitle: string;
+  whyClose: string;
+  showMore: string;
+  showLess: string;
+  srNextAttempt: (when: string) => string;
+  srAllFailed: string;
+  srNoSchedule: string;
+  emptyTitle: string;
+  emptyBody: string;
+  methodLabels: Record<PaymentMethodKind, string>;
+  statusLabels: Record<AttemptStatus, string>;
+}
+
+const DEFAULT_LABELS: RetryScheduleVizLabels = {
+  title: 'Retry schedule',
+  whyButton: 'Why these times?',
+  whyTitle: 'How we schedule retries',
+  whyClose: 'Got it',
+  showMore: 'Show all attempts',
+  showLess: 'Show less',
+  srNextAttempt: (when) => `Next payment retry scheduled for ${when}.`,
+  srAllFailed: 'All retry attempts have failed. Please update your payment method.',
+  srNoSchedule: 'No retry schedule is available.',
+  emptyTitle: 'All retries exhausted',
+  emptyBody:
+    'Every scheduled attempt has failed. Update your payment method to reactivate your subscription.',
+  methodLabels: {
+    card: 'Card',
+    usdc: 'USDC',
+    prepaid: 'Prepaid',
+    bank: 'Bank',
+    other: 'Other',
+  },
+  statusLabels: {
+    past: 'Attempted',
+    upcoming: 'Upcoming',
+    failed: 'Failed',
+    succeeded: 'Succeeded',
+  },
+};
+
+// ─── Heuristic explanations for the "why" popover ───────────
+
+const DEFAULT_WHY_ITEMS = [
+  {
+    icon: <CalendarClock size={14} />,
+    title: 'Off-peak window',
+    body: 'Retries run in early-morning off-peak windows (02:00–06:00 UTC) when bank processors have lower error rates.',
+  },
+  {
+    icon: <TrendingUp size={14} />,
+    title: 'Exponential back-off',
+    body: 'Each subsequent attempt waits longer (1 h → 6 h → 24 h → 72 h) to avoid triggering fraud checks.',
+  },
+  {
+    icon: <BarChart2 size={14} />,
+    title: 'Success-probability model',
+    body: 'Machine-learning scores predict the likelihood of success based on card network, time-of-day, and recent decline codes.',
+  },
+  {
+    icon: <ShieldCheck size={14} />,
+    title: 'Smart method rotation',
+    body: 'If a card is hard-declined, we attempt your next configured method (USDC wallet, prepaid balance) before giving up.',
+  },
+];
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function getProbClass(p: number): 'high' | 'medium' | 'low' {
+  if (p >= 0.65) return 'high';
+  if (p >= 0.35) return 'medium';
+  return 'low';
+}
+
+function MethodIcon({ kind }: { kind: PaymentMethodKind }) {
+  const size = 10;
+  switch (kind) {
+    case 'card':    return <CreditCard size={size} aria-hidden="true" />;
+    case 'usdc':    return <Zap size={size} aria-hidden="true" />;
+    case 'prepaid': return <Wallet size={size} aria-hidden="true" />;
+    case 'bank':    return <BanknoteIcon size={size} aria-hidden="true" />;
+    default:        return null;
+  }
+}
+
+function StatusIcon({ status }: { status: AttemptStatus }) {
+  const size = 14;
+  switch (status) {
+    case 'succeeded': return <Check size={size} aria-hidden="true" />;
+    case 'failed':    return <X size={size} aria-hidden="true" />;
+    case 'upcoming':  return <Clock size={size} aria-hidden="true" />;
+    default:          return <Check size={size} aria-hidden="true" />;
+  }
+}
+
+// Compute a human-readable delta relative to "now"
+function computeDelta(scheduledAt: string, now: Date): string {
+  const diff = new Date(scheduledAt).getTime() - now.getTime();
+  const abs = Math.abs(diff);
+  const isPast = diff < 0;
+  const prefix = isPast ? '−' : '+';
+
+  if (abs < 60_000)              return 'now';
+  if (abs < 3_600_000)           return `${prefix}${Math.round(abs / 60_000)} m`;
+  if (abs < 86_400_000)          return `${prefix}${Math.round(abs / 3_600_000)} h`;
+  if (abs < 86_400_000 * 30)     return `${prefix}${Math.round(abs / 86_400_000)} d`;
+  return `${prefix}${Math.round(abs / (86_400_000 * 30))} mo`;
+}
+
+// ─── Why Popover ─────────────────────────────────────────────
+
+interface WhyPopoverProps {
+  labels: RetryScheduleVizLabels;
+  customContent?: React.ReactNode;
+}
+
+function WhyPopover({ labels, customContent }: WhyPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [positionBelow, setPositionBelow] = useState(false);
+  const rootRef    = useRef<HTMLSpanElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef   = useRef<HTMLButtonElement>(null);
+  const id = useId();
+  const popoverId = `${id}-why-popover`;
+  const titleId   = `${id}-why-title`;
+
+  useModalFocus(popoverRef, {
+    isOpen,
+    onClose: () => setIsOpen(false),
+    initialFocusRef: closeRef,
+  });
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setIsOpen(false);
+    };
+    document.addEventListener('pointerdown', handleClick);
+    return () => document.removeEventListener('pointerdown', handleClick);
+  }, [isOpen]);
+
+  // Flip above/below based on available space
+  useEffect(() => {
+    if (!isOpen) return;
+    const frame = requestAnimationFrame(() => {
+      const popover = popoverRef.current;
+      if (!popover) return;
+      const rect = popover.getBoundingClientRect();
+      setPositionBelow(rect.top < 0);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
+  return (
+    <span className="rsv__why-wrap" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="rsv__why-btn"
+        aria-label={labels.whyTitle}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? popoverId : undefined}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <HelpCircle size={12} aria-hidden="true" />
+        {labels.whyButton}
+      </button>
+
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby={titleId}
+          className={`rsv__why-popover${positionBelow ? ' rsv__why-popover--below' : ''}`}
+        >
+          <h4 id={titleId} className="rsv__why-title">
+            {labels.whyTitle}
+          </h4>
+
+          {customContent ?? (
+            <ul className="rsv__why-list" role="list">
+              {DEFAULT_WHY_ITEMS.map((item) => (
+                <li key={item.title} className="rsv__why-item">
+                  <span className="rsv__why-icon" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                  <p className="rsv__why-text">
+                    <strong>{item.title}</strong>
+                    {item.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <button
+            ref={closeRef}
+            type="button"
+            className="rsv__why-close"
+            onClick={close}
+          >
+            {labels.whyClose}
+          </button>
+        </div>
+      )}
+    </span>
+  );
+}
+
+// ─── Single attempt chip ─────────────────────────────────────
+
+interface AttemptChipProps {
+  attempt: RetryAttempt;
+  isNext: boolean;
+  now: Date;
+  labels: RetryScheduleVizLabels;
+}
+
+function AttemptChip({ attempt, isNext, now, labels }: AttemptChipProps) {
+  const { status, when, scheduledAt, method, successProbability } = attempt;
+  const delta = computeDelta(scheduledAt, now);
+  const prob  = successProbability;
+  const probClass = prob != null ? getProbClass(prob) : null;
+  const probPct   = prob != null ? `${Math.round(prob * 100)}%` : null;
+
+  const isUpcoming   = status === 'upcoming';
+  const itemClasses  = [
+    'rsv__item',
+    `rsv__item--${status}`,
+    isNext && isUpcoming ? 'rsv__item--next' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <li
+      className={itemClasses}
+      aria-current={isNext && isUpcoming ? 'true' : undefined}
+    >
+      {/* Icon chip */}
+      <span
+        className="rsv__chip"
+        aria-hidden="true"
+      >
+        <StatusIcon status={status} />
+      </span>
+
+      {/* Text labels */}
+      <div className="rsv__labels">
+        {/* Absolute date */}
+        <time
+          className="rsv__when"
+          dateTime={scheduledAt}
+          aria-label={`Attempt on ${when}`}
+        >
+          {when}
+        </time>
+
+        {/* Relative delta */}
+        <span className="rsv__delta" aria-hidden="true">
+          {delta}
+        </span>
+
+        {/* Method badge */}
+        {method && (
+          <span
+            className={`rsv__method rsv__method--${method}`}
+            aria-label={`Method: ${labels.methodLabels[method]}`}
+          >
+            <MethodIcon kind={method} />
+            {labels.methodLabels[method]}
+          </span>
+        )}
+
+        {/* Status badge */}
+        <span
+          className={`rsv__status-badge rsv__status-badge--${status}`}
+          aria-label={`Status: ${labels.statusLabels[status]}`}
+        >
+          {labels.statusLabels[status]}
+        </span>
+
+        {/* Probability bar */}
+        {probClass && probPct && (
+          <>
+            <div
+              className="rsv__prob-track"
+              role="meter"
+              aria-label={`Success probability: ${probPct}`}
+              aria-valuenow={Math.round((prob ?? 0) * 100)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div
+                className={`rsv__prob-fill rsv__prob-fill--${probClass}`}
+                style={{ width: probPct }}
+              />
+            </div>
+            <span className="rsv__prob-label" aria-hidden="true">
+              {probPct}
+            </span>
+          </>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────
+
+const DEFAULT_MAX_VISIBLE = 5;
+
+export function RetryScheduleViz({
+  attempts,
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  onShowMore,
+  whyContent,
+  labels: labelOverrides,
+}: RetryScheduleVizProps) {
+  const labels  = { ...DEFAULT_LABELS, ...labelOverrides } as RetryScheduleVizLabels;
+  const [showAll, setShowAll] = useState(false);
+  const [now]    = useState(() => new Date());
+
+  const allFailed  = attempts.length > 0 && attempts.every((a) => a.status === 'failed');
+  const isEmpty    = attempts.length === 0;
+
+  const nextAttempt = attempts.find((a) => a.status === 'upcoming');
+
+  // SR announcement for next-attempt time
+  const srMessage = isEmpty
+    ? labels.srNoSchedule
+    : allFailed
+    ? labels.srAllFailed
+    : nextAttempt
+    ? labels.srNextAttempt(nextAttempt.when)
+    : '';
+
+  // Decide which items to show
+  const clampedMax   = Math.max(1, maxVisible);
+  const showOverflow = !showAll && attempts.length > clampedMax;
+  const visibleItems = showAll ? attempts : attempts.slice(0, clampedMax);
+
+  const handleShowMore = () => {
+    setShowAll(true);
+    onShowMore?.();
+  };
+
+  // Empty / all-failed state
+  if (isEmpty || allFailed) {
+    return (
+      <div className="rsv" data-testid="retry-schedule-viz">
+        {/* SR live region */}
+        <div
+          className="rsv__sr-live"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {srMessage}
+        </div>
+
+        <div className="rsv__empty" role="alert">
+          <AlertTriangle
+            size={24}
+            className="rsv__empty-icon"
+            aria-hidden="true"
+          />
+          <p className="rsv__empty-title">{labels.emptyTitle}</p>
+          <p className="rsv__empty-body">{labels.emptyBody}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rsv" data-testid="retry-schedule-viz">
+      {/* Off-screen SR live region */}
+      <div
+        className="rsv__sr-live"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {srMessage}
+      </div>
+
+      {/* Header */}
+      <div className="rsv__header">
+        <h3 className="rsv__title">{labels.title}</h3>
+        <WhyPopover labels={labels} customContent={whyContent} />
+      </div>
+
+      {/* Scrollable horizontal track */}
+      <div
+        className="rsv__track"
+        role="region"
+        aria-label={labels.title}
+        tabIndex={0}
+      >
+        <ol
+          className="rsv__list"
+          aria-label={labels.title}
+        >
+          {visibleItems.map((attempt) => (
+            <AttemptChip
+              key={attempt.id}
+              attempt={attempt}
+              isNext={attempt.id === nextAttempt?.id}
+              now={now}
+              labels={labels}
+            />
+          ))}
+        </ol>
+      </div>
+
+      {/* Show more / less toggle */}
+      {attempts.length > clampedMax && (
+        <button
+          type="button"
+          className="rsv__overflow-btn"
+          onClick={showOverflow ? handleShowMore : () => setShowAll(false)}
+          aria-expanded={showAll}
+          aria-controls="rsv-list"
+        >
+          {showOverflow ? (
+            <>
+              <ChevronDown size={14} aria-hidden="true" />
+              {labels.showMore} ({attempts.length - clampedMax} more)
+            </>
+          ) : (
+            <>
+              <ChevronUp size={14} aria-hidden="true" />
+              {labels.showLess}
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default RetryScheduleViz;

--- a/src/components/Dunning/RetryTimeline.tsx
+++ b/src/components/Dunning/RetryTimeline.tsx
@@ -1,23 +1,58 @@
+/**
+ * RetryTimeline (updated)
+ * -----------------------
+ * Thin wrapper that maps the original simple RetryAttempt shape
+ * to the richer RetryScheduleViz component.
+ *
+ * Backward-compatible: callers that only supply { id, when, status }
+ * continue to work unchanged; the new optional fields are accepted
+ * via the `retryAttempts` prop when available.
+ */
+import RetryScheduleViz, {
+  type RetryAttempt as RichAttempt,
+} from './RetryScheduleViz';
 import './dunning.css';
 
 interface RetryAttempt {
   id: string;
+  /** Human-readable date label */
   when: string;
   status: 'past' | 'upcoming' | 'failed' | 'succeeded';
+  /**
+   * ISO-8601 timestamp.  Falls back to `when` if not supplied so
+   * computeDelta still works (it may produce a less precise value).
+   */
+  scheduledAt?: string;
+  method?: RichAttempt['method'];
+  successProbability?: number;
 }
 
-export default function RetryTimeline({ attempts }: { attempts: RetryAttempt[] }) {
+interface RetryTimelineProps {
+  attempts: RetryAttempt[];
+  /** Max chips shown before "show more" toggle.  Defaults to 5. */
+  maxVisible?: number;
+  /** Override the "why these times?" popover content */
+  whyContent?: React.ReactNode;
+}
+
+export default function RetryTimeline({
+  attempts,
+  maxVisible,
+  whyContent,
+}: RetryTimelineProps) {
+  const richAttempts: RichAttempt[] = attempts.map((a) => ({
+    ...a,
+    // If `scheduledAt` is missing, use `when` as a fallback.
+    // computeDelta will show "now" or an imprecise delta, which is
+    // acceptable for callers that don't supply machine-readable dates.
+    scheduledAt: a.scheduledAt ?? a.when,
+  }));
+
   return (
-    <ol className="dunning-timeline" aria-label="Retry schedule">
-      {attempts.map((a) => (
-        <li key={a.id} className={`dunning-step dunning-step-${a.status}`}>
-          <span className="dunning-step-icon" aria-hidden="true">{a.status === 'upcoming' ? '⏳' : a.status === 'failed' ? '⚠️' : '✓'}</span>
-          <div className="dunning-step-content">
-            <div className="dunning-step-when">{a.when}</div>
-            <div className="dunning-step-status">{a.status === 'past' ? 'Attempted' : a.status === 'upcoming' ? 'Next attempt' : a.status === 'failed' ? 'Failed' : 'Succeeded'}</div>
-          </div>
-        </li>
-      ))}
-    </ol>
+    <RetryScheduleViz
+      attempts={richAttempts}
+      maxVisible={maxVisible}
+      whyContent={whyContent}
+    />
   );
 }


### PR DESCRIPTION
 Summary
  
  Replaces the opaque RetryTimeline list with a rich, interactive schedule visualization that
  makes the smart-retry dunning strategy transparent to users.
  
  What changed
  
  New: RetryScheduleViz component
  
  - Horizontal timeline with per-attempt chips showing: absolute date/time, relative time delta
  (+4 h, −2 d), payment method badge (card, USDC, prepaid, bank), success probability bar with
  colour coding (green/amber/red), and status badge (Attempted / Upcoming / Failed / Succeeded)
  - Pulsing ring on the next scheduled attempt so it's immediately scannable
  - "Why these times?" popover explaining the four scheduling heuristics: off-peak windows,
  exponential back-off, ML success-probability model, and smart method rotation
  - Overflow toggle — caps visible chips at maxVisible (default 5) with a "Show all (N more)" /
  "Show less" control
  - All-failed and empty-schedule callout states
  - Fully i18n-ready via a labels prop override
  
  Updated: RetryTimeline
  
  - Now a thin backward-compatible wrapper — existing callers with { id, when, status } continue
  to work unchanged; richer fields (scheduledAt, method, successProbability) are opt-in
  
  Accessibility (WCAG 2.1 AA)
  
  - role="status" live region announces next-attempt time and all-failed state to screen readers
  - All interactive elements have focus-visible rings using the design-system focus token
  - Probability bars use role="meter" with aria-valuenow/min/max
  - aria-current="true" marks the next upcoming chip
  - prefers-reduced-motion: disables transitions and pulse animation
  - forced-colors: explicit ButtonBorder / Highlight / Canvas mappings
  
  Responsiveness & RTL
  
  - CSS container queries switch from horizontal scroll to vertical stacked layout below 480 px
  - All connector lines and offsets use CSS logical properties (inset-inline-*) so RTL flips
  automatically
  
  Tests
  
  RetryScheduleViz.test.tsx covers:
  
  - Basic rendering, date/time labels, <time dateTime> attributes
  - All method badge variants, status badge variants
  - Probability meter ARIA values
  - aria-current on the next chip
  - SR live region messages (next attempt, all-failed, empty)
  - Empty / all-failed callout state
  - Show-more / show-less overflow toggle + onShowMore callback
  - "Why these times?" popover (open, close via button / Escape / outside click, focus trap,
  focus restoration, custom content slot)
  - Label overrides
  - Relative delta computation (+h, −d, now)
  - RTL rendering
  - RetryTimeline backward-compatibility wrapper
  
  Before / After
  
  ┌────────┬───────┐
  │ Before                                                │ After │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ Plain ordered list with emoji    │ Horizontal chip timeline with method badges,          │
  │ icons and a date string          │ probability bars, and an explanatory popover          │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ No context on timing strategy    │ "Why these times?" popover surfaces scheduling        │
  │                                  │ heuristics inline                                     │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ No overflow handling             │ Long schedules collapse to 5 chips with a show-more   │
  │                                  │ toggle                                                │
  ├──────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ No SR announcement               │ Live region announces next retry time on mount        │
  └──────────────────────────────────┴───────────────────────────────────────────────────────┘

Closes #836

