### PR TITLE
design: family-plan invitation preview

### DIFF
--- a/src/components/settings/FamilyInvitationPreview.css
+++ b/src/components/settings/FamilyInvitationPreview.css
@@ -1,0 +1,431 @@
+@import '../../styles/tokens.css';
+
+/* ── Root ──────────────────────────────────────────────────────────── */
+.fip-root {
+  background: #0a0a0a;
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  animation: fip-slide-up 0.25s ease-out;
+}
+
+@keyframes fip-slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Header ────────────────────────────────────────────────────────── */
+.fip-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.fip-header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #22d3ee;
+  color: #02131a;
+  flex-shrink: 0;
+}
+
+.fip-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+/* ── Tab bar ───────────────────────────────────────────────────────── */
+.fip-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: var(--space-5);
+  background: #0f0f0f;
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  padding: 3px;
+}
+
+.fip-tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: #64748b;
+  font-size: 0.875rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.fip-tab:hover {
+  color: #e2e8f0;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.fip-tab:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.fip-tab--active {
+  background: #1a1a2e;
+  color: #22d3ee;
+}
+
+.fip-tab--active:hover {
+  background: #1a1a2e;
+  color: #67e8f9;
+}
+
+/* ── Panel ─────────────────────────────────────────────────────────── */
+.fip-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* ── Fields ────────────────────────────────────────────────────────── */
+.fip-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.fip-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.fip-optional {
+  font-weight: 400;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+/* ── Textarea ──────────────────────────────────────────────────────── */
+.fip-textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  background: #0f0f0f;
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  font-family: var(--font-family-body);
+  line-height: var(--leading-normal);
+  resize: vertical;
+  min-height: 80px;
+  transition: border-color 150ms ease;
+}
+
+.fip-textarea::placeholder {
+  color: #475569;
+}
+
+.fip-textarea:focus {
+  outline: none;
+  border-color: #22d3ee;
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.15);
+}
+
+.fip-textarea--error {
+  border-color: #f87171;
+}
+
+.fip-textarea--error:focus {
+  border-color: #f87171;
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.15);
+}
+
+/* ── Character counter ─────────────────────────────────────────────── */
+.fip-counter {
+  font-size: 0.75rem;
+  color: #64748b;
+  text-align: right;
+}
+
+.fip-counter--error {
+  color: #f87171;
+  font-weight: 600;
+}
+
+/* ── Token chips ───────────────────────────────────────────────────── */
+.fip-tokens {
+  background: #0f0f0f;
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.fip-tokens-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-bottom: var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.fip-token-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.fip-token-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  background: rgba(34, 211, 238, 0.1);
+  border: 1px solid rgba(34, 211, 238, 0.25);
+  font-size: 0.75rem;
+  font-family: var(--font-family-mono);
+  color: #22d3ee;
+}
+
+/* ── Send test ─────────────────────────────────────────────────────── */
+.fip-test {
+  background: #0f0f0f;
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+
+.fip-test-row {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.fip-test-input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  background: #0a0a0a;
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: border-color 150ms ease;
+}
+
+.fip-test-input::placeholder {
+  color: #475569;
+}
+
+.fip-test-input:focus {
+  outline: none;
+  border-color: #22d3ee;
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.15);
+}
+
+.fip-test-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, #22d3ee, #2dd4bf);
+  color: #02131a;
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 150ms ease;
+}
+
+.fip-test-btn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.fip-test-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.fip-test-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.fip-test-sent {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: rgba(52, 211, 153, 0.14);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  color: #6ee7b7;
+  font-size: 0.8125rem;
+}
+
+/* ── Select ────────────────────────────────────────────────────────── */
+.fip-select {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid #2d2d44;
+  border-radius: var(--radius-md);
+  background: #0f0f0f;
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 150ms ease;
+}
+
+.fip-select:focus {
+  outline: none;
+  border-color: #22d3ee;
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.15);
+}
+
+/* ── Email preview card ────────────────────────────────────────────── */
+.fip-email-preview {
+  background: #ffffff;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  max-width: 600px;
+}
+
+.fip-email-header {
+  padding: var(--space-4);
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fip-email-header-row {
+  display: flex;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+}
+
+.fip-email-header-label {
+  font-weight: 600;
+  color: #475569;
+  min-width: 54px;
+}
+
+.fip-email-header-value {
+  color: #334155;
+}
+
+.fip-email-subject {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.fip-email-body {
+  padding: var(--space-6) var(--space-5);
+  background: #ffffff;
+}
+
+.fip-email-paragraph {
+  margin: 0 0 12px;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: #1e293b;
+}
+
+.fip-email-paragraph:last-of-type {
+  margin-bottom: 0;
+}
+
+.fip-email-cta {
+  margin: 20px 0;
+  text-align: center;
+}
+
+.fip-email-cta-text {
+  display: inline-block;
+  padding: 10px 28px;
+  background: #067d99;
+  color: #ffffff;
+  border-radius: var(--radius-md);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.fip-email-footer-text {
+  margin: 16px 0 0;
+  font-size: 0.8125rem;
+  color: #64748b;
+  line-height: 1.5;
+  border-top: 1px solid #e2e8f0;
+  padding-top: 16px;
+}
+
+/* ── Responsive ────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .fip-root {
+    padding: var(--space-4);
+  }
+
+  .fip-test-row {
+    flex-direction: column;
+  }
+
+  .fip-test-btn {
+    justify-content: center;
+  }
+
+  .fip-email-preview {
+    max-width: 100%;
+  }
+}
+
+/* ── RTL ───────────────────────────────────────────────────────────── */
+[dir="rtl"] .fip-email-header-row {
+  flex-direction: row-reverse;
+}
+
+[dir="rtl"] .fip-counter {
+  text-align: left;
+}
+
+/* ── Print ─────────────────────────────────────────────────────────── */
+@media print {
+  .fip-root {
+    border: 1px solid #ccc;
+    animation: none;
+  }
+
+  .fip-tabs,
+  .fip-test,
+  .fip-tokens,
+  .fip-select {
+    display: none;
+  }
+
+  .fip-panel {
+    gap: 0;
+  }
+
+  .fip-email-preview {
+    max-width: 100%;
+    border: 1px solid #999;
+  }
+}

--- a/src/components/settings/FamilyInvitationPreview.test.tsx
+++ b/src/components/settings/FamilyInvitationPreview.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Tests for FamilyInvitationPreview component.
+ *
+ * Edge-cases covered:
+ *   - Long merchant names (overflow/truncation)
+ *   - RTL rendering (dir="rtl" wrapper)
+ *   - Screen-reader labels (aria-selected, aria-live, role="tab")
+ *   - Character counter boundary (0, 200, >200)
+ *   - Token resolution in preview
+ *   - Send-test flow (email input, button state, success message)
+ *   - Tab switching preserves state
+ *   - Keyboard navigation (Enter on send-test)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import FamilyInvitationPreview from './FamilyInvitationPreview'
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function renderPreview(overrides: Partial<React.ComponentProps<typeof FamilyInvitationPreview>> = {}) {
+  const onSendTest = overrides.onSendTest ?? vi.fn()
+  const utils = render(
+    <FamilyInvitationPreview
+      merchantName="Acme Corp"
+      memberCount={4}
+      onSendTest={onSendTest}
+      {...overrides}
+    />,
+  )
+  return { ...utils, onSendTest }
+}
+
+// ── Rendering and structure ─────────────────────────────────────────────
+
+describe('FamilyInvitationPreview', () => {
+  it('renders the root region with a heading', () => {
+    renderPreview()
+    expect(screen.getByRole('region')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /family plan invitation/i })).toBeInTheDocument()
+  })
+
+  it('renders two tabs with role="tab"', () => {
+    renderPreview()
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveTextContent(/edit/i)
+    expect(tabs[1]).toHaveTextContent(/preview/i)
+  })
+
+  it('marks the Edit tab as selected by default', () => {
+    renderPreview()
+    const editTab = screen.getByRole('tab', { name: /edit/i })
+    expect(editTab).toHaveAttribute('aria-selected', 'true')
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    expect(previewTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  // ── Editor panel ──────────────────────────────────────────────────────
+
+  it('shows the editor panel by default', () => {
+    renderPreview()
+    expect(screen.getByRole('tabpanel', { name: /edit/i })).toBeInTheDocument()
+  })
+
+  it('contains the note textarea with character counter', () => {
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    expect(textarea).toBeInTheDocument()
+    expect(textarea).toHaveValue('')
+    expect(screen.getByText(/200 \/ 200 characters remaining/i)).toBeInTheDocument()
+  })
+
+  it('does not show the preview panel by default', () => {
+    renderPreview()
+    expect(screen.queryByRole('tabpanel', { name: /preview/i })).toBeNull()
+  })
+
+  // ── Tab switching ─────────────────────────────────────────────────────
+
+  it('switches to preview panel when clicking Preview tab', async () => {
+    renderPreview()
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    expect(screen.getByRole('tabpanel', { name: /preview/i })).toBeInTheDocument()
+    expect(screen.queryByRole('tabpanel', { name: /edit/i })).toBeNull()
+  })
+
+  it('preserves note text when switching tabs', async () => {
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    await userEvent.type(textarea, 'Welcome to the plan!')
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    const editTab = screen.getByRole('tab', { name: /edit/i })
+    await userEvent.click(editTab)
+    expect(screen.getByRole('textbox', { name: /personal note/i })).toHaveValue('Welcome to the plan!')
+  })
+
+  // ── Character counter ─────────────────────────────────────────────────
+
+  it('decrements the character counter as the user types', async () => {
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    await userEvent.type(textarea, 'Hello')
+    expect(screen.getByText(/195 \/ 200 characters remaining/i)).toBeInTheDocument()
+  })
+
+  it('prevents typing past 200 characters', async () => {
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    const longText = 'A'.repeat(210)
+    await userEvent.type(textarea, longText)
+    expect(textarea).toHaveValue('A'.repeat(200))
+    expect(screen.getByText(/0 \/ 200 characters remaining/i)).toBeInTheDocument()
+  })
+
+  it('shows error styling when over 200 characters', () => {
+    // The component caps at 200; test the aria-invalid behavior by
+    // verifying the textarea can never go over the limit.
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    expect(textarea).toHaveAttribute('aria-invalid', 'false')
+  })
+
+  // ── Available tokens ──────────────────────────────────────────────────
+
+  it('shows the token help section', () => {
+    renderPreview()
+    expect(screen.getByText(/available tokens/i)).toBeInTheDocument()
+    expect(screen.getByText('{recipient_name}')).toBeInTheDocument()
+    expect(screen.getByText('{merchant_name}')).toBeInTheDocument()
+    expect(screen.getByText('{member_count}')).toBeInTheDocument()
+  })
+
+  // ── Preview panel ─────────────────────────────────────────────────────
+
+  it('shows member selector in preview', async () => {
+    renderPreview()
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    expect(screen.getByRole('combobox', { name: /preview for member/i })).toBeInTheDocument()
+  })
+
+  it('renders email preview with correct merchant name', async () => {
+    renderPreview({ merchantName: 'TestCo' })
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    expect(screen.getByText(/you're invited to testco family plan/i)).toBeInTheDocument()
+  })
+
+  it('resolves {merchant_name} token in the preview body', async () => {
+    renderPreview({ merchantName: 'MegaCorp' })
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    const matches = screen.getAllByText(/megacorp/i)
+    expect(matches.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('resolves {member_count} token in the preview body', async () => {
+    renderPreview({ memberCount: 6 })
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    const matches = screen.getAllByText(/6 members/i)
+    expect(matches.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('uses the custom note as the preview body when provided', async () => {
+    renderPreview()
+    const textarea = screen.getByRole('textbox', { name: /personal note/i })
+    await userEvent.type(textarea, 'Welcome to the team!')
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    expect(screen.getByText(/welcome to the team!/i)).toBeInTheDocument()
+  })
+
+  // ── Send test ─────────────────────────────────────────────────────────
+
+  it('shows the send-test section in the editor panel', () => {
+    renderPreview()
+    expect(screen.getByText(/send test invitation/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/enter recipient email/i)).toBeInTheDocument()
+  })
+
+  it('disables send-test button when email is empty', () => {
+    renderPreview()
+    const btn = screen.getByRole('button', { name: /send test/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('enables send-test button when email is entered', async () => {
+    renderPreview()
+    const input = screen.getByPlaceholderText(/enter recipient email/i)
+    await userEvent.type(input, 'test@example.com')
+    const btn = screen.getByRole('button', { name: /send test/i })
+    expect(btn).toBeEnabled()
+  })
+
+  it('calls onSendTest with the email when Send Test is clicked', async () => {
+    const onSendTest = vi.fn()
+    renderPreview({ onSendTest })
+    const input = screen.getByPlaceholderText(/enter recipient email/i)
+    await userEvent.type(input, 'family@example.com')
+    const btn = screen.getByRole('button', { name: /send test/i })
+    await userEvent.click(btn)
+    expect(onSendTest).toHaveBeenCalledWith('family@example.com')
+  })
+
+  it('shows a success message after sending a test', async () => {
+    const onSendTest = vi.fn()
+    renderPreview({ onSendTest })
+    const input = screen.getByPlaceholderText(/enter recipient email/i)
+    await userEvent.type(input, 'success@test.com')
+    const btn = screen.getByRole('button', { name: /send test/i })
+    await userEvent.click(btn)
+    expect(screen.getByText(/test invitation sent to success@test.com/i)).toBeInTheDocument()
+  })
+
+  it('sends test on Enter key in the email input', async () => {
+    const onSendTest = vi.fn()
+    renderPreview({ onSendTest })
+    const input = screen.getByPlaceholderText(/enter recipient email/i)
+    await userEvent.type(input, 'enter@test.com{Enter}')
+    expect(onSendTest).toHaveBeenCalledWith('enter@test.com')
+  })
+
+  // ── Long merchant names ───────────────────────────────────────────────
+
+  it('renders a very long merchant name without breaking layout', async () => {
+    const longName = 'M'.repeat(100)
+    renderPreview({ merchantName: longName })
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    await userEvent.click(previewTab)
+    const matches = screen.getAllByText(new RegExp(longName, 'i'))
+    expect(matches.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // ── RTL ───────────────────────────────────────────────────────────────
+
+  it('renders correctly in an RTL context', () => {
+    render(
+      <div dir="rtl">
+        <FamilyInvitationPreview
+          merchantName="شركة"
+          memberCount={3}
+          onSendTest={vi.fn()}
+        />
+      </div>,
+    )
+    expect(screen.getByRole('region')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /edit/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /preview/i })).toBeInTheDocument()
+  })
+
+  // ── Accessibility ─────────────────────────────────────────────────────
+
+  it('uses aria-live="polite" for the character counter', () => {
+    renderPreview()
+    const counter = screen.getByText(/200 \/ 200 characters remaining/i)
+    expect(counter.closest('[aria-live="polite"]')).toBeInTheDocument()
+  })
+
+  it('uses aria-live="polite" for the test-sent message', async () => {
+    const onSendTest = vi.fn()
+    renderPreview({ onSendTest })
+    const input = screen.getByPlaceholderText(/enter recipient email/i)
+    await userEvent.type(input, 'a11y@test.com')
+    const btn = screen.getByRole('button', { name: /send test/i })
+    await userEvent.click(btn)
+    const msg = screen.getByText(/test invitation sent to/i)
+    expect(msg.closest('[aria-live="polite"]')).toBeInTheDocument()
+  })
+
+  it('has accessible names for the tab buttons', () => {
+    renderPreview()
+    const editTab = screen.getByRole('tab', { name: /edit/i })
+    const previewTab = screen.getByRole('tab', { name: /preview/i })
+    expect(editTab).toBeInTheDocument()
+    expect(previewTab).toBeInTheDocument()
+  })
+
+  it('sets aria-controls on each tab', () => {
+    renderPreview()
+    const editTab = screen.getByRole('tab', { name: /edit/i })
+    expect(editTab).toHaveAttribute('aria-controls')
+  })
+})

--- a/src/components/settings/FamilyInvitationPreview.tsx
+++ b/src/components/settings/FamilyInvitationPreview.tsx
@@ -1,0 +1,252 @@
+import { useState, useId, useCallback } from 'react'
+import { Send, Mail, Users, Edit3, Eye } from 'lucide-react'
+import './FamilyInvitationPreview.css'
+
+const NOTE_MAX_LENGTH = 200
+
+interface FamilyInvitationPreviewProps {
+  merchantName: string
+  memberCount: number
+  onSendTest: (email: string) => void
+}
+
+interface FamilyMember {
+  id: string
+  name: string
+  email: string
+}
+
+const MOCK_MEMBERS: FamilyMember[] = [
+  { id: '1', name: 'Alice Johnson', email: 'alice@example.com' },
+  { id: '2', name: 'Bob Smith', email: 'bob@example.com' },
+  { id: '3', name: 'Charlie Lee', email: 'charlie@example.com' },
+]
+
+function resolveTokens(template: string, merchantName: string, memberCount: number, recipientName: string): string {
+  return template
+    .replace(/\{merchant_name\}/g, merchantName)
+    .replace(/\{member_count\}/g, String(memberCount))
+    .replace(/\{recipient_name\}/g, recipientName)
+}
+
+export default function FamilyInvitationPreview({
+  merchantName,
+  memberCount,
+  onSendTest,
+}: FamilyInvitationPreviewProps) {
+  const headingId = useId()
+  const editorTabId = useId()
+  const previewTabId = useId()
+  const noteId = useId()
+  const testEmailId = useId()
+
+  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit')
+  const [note, setNote] = useState('')
+  const [selectedMemberId, setSelectedMemberId] = useState(MOCK_MEMBERS[0]?.id ?? '')
+  const [testEmail, setTestEmail] = useState('')
+  const [testSent, setTestSent] = useState(false)
+
+  const selectedMember = MOCK_MEMBERS.find((m) => m.id === selectedMemberId) ?? MOCK_MEMBERS[0]
+
+  const charsRemaining = NOTE_MAX_LENGTH - note.length
+  const isOverLimit = note.length > NOTE_MAX_LENGTH
+
+  const handleNoteChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    if (val.length <= NOTE_MAX_LENGTH) {
+      setNote(val)
+    }
+  }, [])
+
+  const handleSendTest = useCallback(() => {
+    const email = testEmail.trim()
+    if (!email) return
+    onSendTest(email)
+    setTestSent(true)
+    setTimeout(() => setTestSent(false), 3000)
+  }, [testEmail, onSendTest])
+
+  const previewSubject = `You're invited to ${merchantName} family plan`
+  const previewBody = resolveTokens(
+    note || `Hi {recipient_name},\n\nYou've been invited to join the {merchant_name} family plan, which covers {member_count} members. Click the link below to accept your invitation.`,
+    merchantName,
+    memberCount,
+    selectedMember?.name ?? 'there',
+  )
+
+  return (
+    <div
+      className="fip-root"
+      role="region"
+      aria-labelledby={headingId}
+    >
+      <div className="fip-header">
+        <div className="fip-header-icon" aria-hidden="true">
+          <Mail size={18} />
+        </div>
+        <h2 id={headingId} className="fip-heading">Family Plan Invitation</h2>
+      </div>
+
+      {/* Tab bar */}
+      <div className="fip-tabs" role="tablist" aria-label="Invitation editor mode">
+        <button
+          id={editorTabId}
+          role="tab"
+          aria-selected={activeTab === 'edit'}
+          aria-controls="fip-editor-panel"
+          className={`fip-tab ${activeTab === 'edit' ? 'fip-tab--active' : ''}`}
+          onClick={() => setActiveTab('edit')}
+        >
+          <Edit3 size={14} aria-hidden="true" />
+          Edit
+        </button>
+        <button
+          id={previewTabId}
+          role="tab"
+          aria-selected={activeTab === 'preview'}
+          aria-controls="fip-preview-panel"
+          className={`fip-tab ${activeTab === 'preview' ? 'fip-tab--active' : ''}`}
+          onClick={() => setActiveTab('preview')}
+        >
+          <Eye size={14} aria-hidden="true" />
+          Preview
+        </button>
+      </div>
+
+      {/* Editor panel */}
+      {activeTab === 'edit' && (
+        <div
+          id="fip-editor-panel"
+          role="tabpanel"
+          aria-labelledby={editorTabId}
+          className="fip-panel"
+        >
+          {/* Note field */}
+          <div className="fip-field">
+            <label htmlFor={noteId} className="fip-label">
+              Personal note
+              <span className="fip-optional">(optional)</span>
+            </label>
+            <textarea
+              id={noteId}
+              className={`fip-textarea ${isOverLimit ? 'fip-textarea--error' : ''}`}
+              rows={4}
+              placeholder="Add a personal message to the invitation..."
+              value={note}
+              onChange={handleNoteChange}
+              aria-describedby={`${noteId}-counter`}
+              aria-invalid={isOverLimit}
+            />
+            <div
+              id={`${noteId}-counter`}
+              className={`fip-counter ${isOverLimit ? 'fip-counter--error' : ''}`}
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {charsRemaining} / {NOTE_MAX_LENGTH} characters remaining
+            </div>
+          </div>
+
+          {/* Token help */}
+          <div className="fip-tokens" role="note">
+            <div className="fip-tokens-label">Available tokens:</div>
+            <div className="fip-token-chips">
+              <code className="fip-token-chip">{'{recipient_name}'}</code>
+              <code className="fip-token-chip">{'{merchant_name}'}</code>
+              <code className="fip-token-chip">{'{member_count}'}</code>
+            </div>
+          </div>
+
+          {/* Send test */}
+          <div className="fip-test">
+            <label htmlFor={testEmailId} className="fip-label">
+              Send test invitation
+            </label>
+            <div className="fip-test-row">
+              <input
+                id={testEmailId}
+                type="email"
+                className="fip-test-input"
+                placeholder="Enter recipient email"
+                value={testEmail}
+                onChange={(e) => setTestEmail(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSendTest() }}
+              />
+              <button
+                type="button"
+                className="fip-test-btn"
+                onClick={handleSendTest}
+                disabled={!testEmail.trim()}
+                aria-label={`Send test invitation to ${testEmail.trim() || 'no recipient'}`}
+              >
+                <Send size={14} aria-hidden="true" />
+                Send Test
+              </button>
+            </div>
+            {testSent && (
+              <div className="fip-test-sent" role="status" aria-live="polite">
+                Test invitation sent to {testEmail}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Preview panel */}
+      {activeTab === 'preview' && (
+        <div
+          id="fip-preview-panel"
+          role="tabpanel"
+          aria-labelledby={previewTabId}
+          className="fip-panel"
+        >
+          {/* Member selector */}
+          <div className="fip-field">
+            <label className="fip-label" id="fip-member-label">
+              <Users size={14} aria-hidden="true" />
+              Preview for member
+            </label>
+            <select
+              className="fip-select"
+              value={selectedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
+              aria-labelledby="fip-member-label"
+            >
+              {MOCK_MEMBERS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name} ({m.email})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Email preview card */}
+          <div className="fip-email-preview" role="article" aria-label="Invitation email preview">
+            <div className="fip-email-header">
+              <div className="fip-email-header-row">
+                <span className="fip-email-header-label">To:</span>
+                <span className="fip-email-header-value">{selectedMember?.email}</span>
+              </div>
+              <div className="fip-email-header-row">
+                <span className="fip-email-header-label">Subject:</span>
+                <span className="fip-email-header-value fip-email-subject">{previewSubject}</span>
+              </div>
+            </div>
+            <div className="fip-email-body">
+              {previewBody.split('\n').map((line, i) => (
+                <p key={i} className="fip-email-paragraph">{line || '\u00A0'}</p>
+              ))}
+              <div className="fip-email-cta">
+                <span className="fip-email-cta-text">Accept Invitation</span>
+              </div>
+              <p className="fip-email-footer-text">
+                This invitation was sent by {merchantName}. You are receiving this because
+                a family plan organizer invited you to join their plan covering {memberCount} members.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/settings/FamilyPlanSettings.tsx
+++ b/src/components/settings/FamilyPlanSettings.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { Users, Plus } from 'lucide-react'
+import FamilyInvitationPreview from './FamilyInvitationPreview'
+
+interface FamilyMember {
+  id: string
+  name: string
+  email: string
+  status: 'pending' | 'active' | 'removed'
+  joinedAt?: string
+}
+
+export default function FamilyPlanSettings() {
+  const [familyMembers] = useState<FamilyMember[]>([
+    { id: '1', name: 'Alice Johnson', email: 'alice@example.com', status: 'active', joinedAt: '2026-06-15' },
+    { id: '2', name: 'Bob Smith', email: 'bob@example.com', status: 'pending' },
+    { id: '3', name: 'Charlie Lee', email: 'charlie@example.com', status: 'pending' },
+  ])
+
+  const activeCount = familyMembers.filter((m) => m.status === 'active').length + 1 // +1 for the admin
+  const pendingCount = familyMembers.filter((m) => m.status === 'pending').length
+
+  const handleSendTest = (email: string) => {
+    console.log('Sending test invitation to:', email)
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '2rem' }}>
+        <h2 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600, color: '#e2e8f0', marginBottom: '0.5rem' }}>
+          Family Plan Settings
+        </h2>
+        <p style={{ margin: 0, fontSize: '0.875rem', color: '#64748b' }}>
+          Manage your family plan members and invitation preferences
+        </p>
+      </div>
+
+      {/* Members overview */}
+      <div style={{ marginBottom: '2rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <Users size={20} style={{ color: '#67d5f0' }} />
+            <h3 style={{ margin: 0, fontSize: '1rem', fontWeight: 600, color: '#e2e8f0' }}>
+              Family Members
+            </h3>
+            <span style={{ background: '#2d2d44', color: '#94a3b8', fontSize: '0.75rem', padding: '0.25rem 0.5rem', borderRadius: '4px' }}>
+              {activeCount} active
+            </span>
+            {pendingCount > 0 && (
+              <span style={{ background: 'rgba(245, 158, 11, 0.16)', color: '#fbbf24', fontSize: '0.75rem', padding: '0.25rem 0.5rem', borderRadius: '4px' }}>
+                {pendingCount} pending
+              </span>
+            )}
+          </div>
+          <button
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.5rem 1rem',
+              borderRadius: '6px',
+              border: '1px solid #2d2d44',
+              background: 'transparent',
+              color: '#e2e8f0',
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            <Plus size={14} />
+            Add Member
+          </button>
+        </div>
+
+        <div style={{ background: '#0a0a0a', borderRadius: '6px', border: '1px solid #2d2d44', overflow: 'hidden' }}>
+          {/* Admin row */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '1rem 1.5rem', borderBottom: '1px solid #2d2d44', background: 'rgba(34, 211, 238, 0.04)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+              <div style={{ width: '40px', height: '40px', borderRadius: '50%', background: 'linear-gradient(135deg, #22d3ee, #2dd4bf)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#02131a', fontWeight: 700, fontSize: '0.875rem' }}>
+                A
+              </div>
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                  <span style={{ fontWeight: 500, color: '#e2e8f0' }}>You (Admin)</span>
+                  <span style={{ background: 'rgba(34, 211, 238, 0.15)', color: '#22d3ee', fontSize: '0.75rem', padding: '0.125rem 0.5rem', borderRadius: '4px', fontWeight: 500 }}>
+                    Owner
+                  </span>
+                </div>
+                <div style={{ fontSize: '0.875rem', color: '#64748b' }}>admin@acme.com</div>
+              </div>
+            </div>
+          </div>
+
+          {familyMembers.map((member, index) => (
+            <div
+              key={member.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '1rem 1.5rem',
+                borderBottom: index < familyMembers.length - 1 ? '1px solid #2d2d44' : 'none',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                <div style={{ width: '40px', height: '40px', borderRadius: '50%', background: '#2d2d44', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#94a3b8', fontWeight: 700, fontSize: '0.875rem' }}>
+                  {member.name.charAt(0)}
+                </div>
+                <div>
+                  <div style={{ fontWeight: 500, color: '#e2e8f0', marginBottom: '0.25rem' }}>
+                    {member.name}
+                  </div>
+                  <div style={{ fontSize: '0.875rem', color: '#64748b' }}>
+                    {member.email}
+                  </div>
+                </div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                <span
+                  style={{
+                    padding: '0.25rem 0.75rem',
+                    borderRadius: '4px',
+                    fontSize: '0.75rem',
+                    fontWeight: 500,
+                    background:
+                      member.status === 'active'
+                        ? 'rgba(16, 185, 129, 0.16)'
+                        : member.status === 'pending'
+                        ? 'rgba(245, 158, 11, 0.16)'
+                        : 'rgba(100, 116, 139, 0.16)',
+                    color:
+                      member.status === 'active'
+                        ? '#34d399'
+                        : member.status === 'pending'
+                        ? '#fbbf24'
+                        : '#94a3b8',
+                  }}
+                >
+                  {member.status.charAt(0).toUpperCase() + member.status.slice(1)}
+                </span>
+                {member.joinedAt && (
+                  <span style={{ fontSize: '0.75rem', color: '#64748b' }}>
+                    Joined {new Date(member.joinedAt).toLocaleDateString()}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Invitation preview */}
+      <div style={{ marginBottom: '2rem' }}>
+        <FamilyInvitationPreview
+          merchantName="Acme Corporation"
+          memberCount={activeCount + pendingCount}
+          onSendTest={handleSendTest}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
-import { CreditCard, Key, Settings as SettingsIcon, Shield, SlidersHorizontal, Tags, Users } from 'lucide-react'
+import { CreditCard, Key, Settings as SettingsIcon, Shield, SlidersHorizontal, Tags, Users, Home } from 'lucide-react'
 import OrganizationSettings from '../components/settings/OrganizationSettings'
 import BillingSettings from '../components/settings/BillingSettings'
 import ApiKeysSettings from '../components/settings/ApiKeysSettings'
 import DensityPreview from '../components/settings/DensityPreview'
+import FamilyPlanSettings from '../components/settings/FamilyPlanSettings'
 import './Settings.css'
 
-type SettingsTab = 'organization' | 'billing' | 'api-keys' | 'tags' | 'appearance'
+type SettingsTab = 'organization' | 'billing' | 'api-keys' | 'tags' | 'appearance' | 'family-plan'
 
 // Wrapper component for ManageTagsSettings with state
 function ManageTagsWrapper() {
@@ -81,6 +82,13 @@ const settingsSections: SettingsSection[] = [
     icon: SlidersHorizontal,
     description: 'Customize interface density and visual preferences',
     component: DensityPreview,
+  },
+  {
+    id: 'family-plan',
+    label: 'Family Plan',
+    icon: Home,
+    description: 'Manage family plan members and invitation settings',
+    component: FamilyPlanSettings,
   },
 ]
 


### PR DESCRIPTION
Closes #376

---

Design a family-plan invitation email preview panel in Settings with editor+preview split layout, 200-char note field, token resolution, member selector, and send-test action.