### PR TITLE
feat: add print-optimized styles and footer contact information to pr…

### DIFF
--- a/src/components/PricingCard.tsx
+++ b/src/components/PricingCard.tsx
@@ -161,7 +161,7 @@ export default function PricingCard({
           {/* CTA Button */}
           <button
             onClick={onButtonClick}
-            className={`w-full py-4 px-6 rounded-2xl font-bold transition-all flex items-center justify-center gap-2 group/btn ${
+            className={`w-full py-4 px-6 rounded-2xl font-bold transition-all flex items-center justify-center gap-2 group/btn print:hidden ${
               useGradientButton
                 ? "bg-linear-to-r from-cyan-400 to-teal-500 hover:from-cyan-300 hover:to-teal-400 text-black shadow-[0_0_20px_rgba(34,211,238,0.3)] hover:shadow-[0_0_30px_rgba(34,211,238,0.5)] transform hover:-translate-y-1"
                 : "bg-white/5 hover:bg-white/10 text-white border border-white/10 hover:border-white/20 transform hover:-translate-y-1"
@@ -172,6 +172,11 @@ export default function PricingCard({
               <ArrowRight size={18} className="transform group-hover/btn:translate-x-1 transition-transform" />
             )}
           </button>
+
+          {/* Print CTA */}
+          <div className="hidden print:block text-slate-800 text-center mt-4 font-semibold text-sm">
+            stellabill.com/contact
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/pricing/FeatureComparison.module.css
+++ b/src/components/pricing/FeatureComparison.module.css
@@ -437,6 +437,15 @@
    Print stylesheet
    ============================================================================= */
 @media print {
+  @page {
+    size: A4 landscape;
+    margin: 1.5cm;
+  }
+
+  thead {
+    display: table-header-group;
+  }
+
   .container {
     max-width: 100%;
     padding: 0;

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -139,6 +139,11 @@ export default function Pricing() {
         <section style={{ marginBottom: "6rem" }}>
           <FeatureComparison />
         </section>
+
+        {/* Print CTA under matrix */}
+        <div className="hidden print:block text-center pt-8 text-black text-lg font-medium">
+          Ready to get started? Visit <strong>stellabill.com/pricing</strong>
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
Closes  #388

## Description


Sales teams frequently print the Pricing page to hand out, but the current print output cut off feature rows. This PR introduces a print layout that reflows the feature matrix to fit perfectly on A4 landscape, hides interactive web elements, and introduces clean, printed URLs for physical handouts.

## Changes Included
- **A4 Landscape Layout:** Added robust `@page` rules to `FeatureComparison.module.css` setting `size: A4 landscape` with appropriate print margins.
- **Header Repeat:** Assigned `display: table-header-group` to the `<thead>` of the feature matrix to ensure column headers reliably repeat across page breaks.
- **Replaced CTA Buttons:** Updated `PricingCard.tsx` to automatically hide interactive buttons during print (`print:hidden`) and swap them out for a clean, printed URL (`stellabill.com/contact`).
- **Additional Print CTA:** Appended an additional printed CTA URL (`stellabill.com/pricing`) just underneath the feature comparison matrix in `Pricing.tsx`.

## Validation
- [x] Tested print layout manually in Chrome/Firefox (using `Cmd+P` / `Ctrl+P`)
- [x] Validated A4 layout behaves responsively and feature rows are protected from inappropriate page breaks.
- [x] Verified accessibility and responsive assumptions for the web layout are unaffected.
- [x] `pnpm lint` and `pnpm test` executed (pre-existing warnings noted).
