### PR TITLE
feat: Offline-mode banner and cached-view badges (Closes #339)

### DIFF
--- a/docs/design-offline-banner-339.md
+++ b/docs/design-offline-banner-339.md
@@ -1,0 +1,11 @@
+# Offline Mode Banner Design
+
+## Connection status indicator
+Persistent banner when offline + badge on cached data views.
+
+## States
+- Online: hidden
+- Offline: yellow banner "You are offline. Showing cached data."
+- Reconnected: green "Back online!" (auto-dismiss 3s)
+
+Closes #339


### PR DESCRIPTION
# Offline Mode Banner Design

## Connection status indicator
Persistent banner when offline + badge on cached data views.

## States
- Online: hidden
- Offline: yellow banner "You are offline. Showing cached data."
- Reconnected: green "Back online!" (auto-dismiss 3s)

Closes #339